### PR TITLE
Manage `Session` instances internally

### DIFF
--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -16,13 +16,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Private
 
     private let baseURL = URL(string: "http://localhost:3000")!
-    private let sharedProcessPool = WKProcessPool()
-    private lazy var session = makeSession()
-    private lazy var modalSession = makeSession()
+    private lazy var turboNavigationController = TurboNavigationController(navigationDelegate: self, pathConfiguration: pathConfiguration)
     private lazy var pathConfiguration = PathConfiguration(sources: [
         .server(baseURL.appending(path: "/configuration"))
     ])
-    private lazy var turboNavigationController = TurboNavigationController(session: session, modalSession: modalSession)
 
     private func createWindow(in windowScene: UIWindowScene) {
         let window = UIWindow(windowScene: windowScene)
@@ -34,27 +31,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         turboNavigationController.route(baseURL)
     }
-
-    private func makeSession() -> Session {
-        let configuration = WKWebViewConfiguration()
-        configuration.applicationNameForUserAgent = "Turbo Native iOS"
-        configuration.processPool = sharedProcessPool
-
-        let session = Session(webViewConfiguration: configuration)
-        session.pathConfiguration = pathConfiguration
-        session.delegate = self
-        return session
-    }
 }
 
-extension SceneDelegate: SessionDelegate {
-    func session(_ session: Turbo.Session, didProposeVisit proposal: Turbo.VisitProposal) {
-        turboNavigationController.route(proposal)
-    }
-
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
+extension SceneDelegate: TurboNavigationDelegate {
+    func session(_ session: Turbo.Session, didFailRequestForVisitable visitable: Turbo.Visitable, error: Error) {
         print("An error occurred loading a visit:", error)
     }
-
-    func sessionWebViewProcessDidTerminate(_ session: Turbo.Session) {}
 }

--- a/Sources/TurboNavigationController/TurboConfig.swift
+++ b/Sources/TurboNavigationController/TurboConfig.swift
@@ -1,0 +1,25 @@
+import Turbo
+import WebKit
+
+public class TurboConfig {
+    public static let shared = TurboConfig()
+
+    /// Override to set a custom user agent.
+    /// Include "Turbo Native" to use `turbo_native_app?` on your Rails server.
+    public var userAgent = "Turbo Native iOS"
+
+    // MARK: - Internal
+
+    func makeWebView() -> WKWebView {
+        let configuration = WKWebViewConfiguration()
+        configuration.applicationNameForUserAgent = userAgent
+        configuration.processPool = sharedProcessPool
+        return WKWebView(frame: .zero, configuration: configuration)
+    }
+
+    // MARK: - Private
+
+    private let sharedProcessPool = WKProcessPool()
+
+    private init() {}
+}


### PR DESCRIPTION
This PR moves Turbo `Session` instances internal to the package, farther abstracting the concept of the underlying turbo-ios framework. It accomplishes this by making `TurboNavigationController` create sessions on its own and become the `SessionDelegate`. 

Errors are still passed directly to the `TurboNavigationDelegate` but could provide a default implementation internal to the package.

One downside to this approach is that if you have 5 instances of `TurboNavigationDelegate` you might have _10_ instances of `Session` - 5 for each main navigation stack and other 5 for each modal stack. When you really only need a single modal `Session` at any given time.