### PR TITLE
Add error handling to demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Rename project to Turbo Navigator
 * Add option to pass in custom `UINavigationController` subclasses
 * Add tests to handle most of the navigation flows
+* Add error handling example to Demo project from turbo-ios
 
 ### Breaking changes
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		8462832529B8C6B5004EFC9A /* TurboNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 8462832429B8C6B5004EFC9A /* TurboNavigator */; };
+		8462832729B90BB9004EFC9A /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8462832629B90BB9004EFC9A /* ErrorPresenter.swift */; };
 		8484C2E929B132D20018596C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484C2E829B132D20018596C /* AppDelegate.swift */; };
 		8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484C2EA29B132D20018596C /* SceneDelegate.swift */; };
 		8484C2F229B132D30018596C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8484C2F129B132D30018596C /* Assets.xcassets */; };
@@ -16,6 +17,7 @@
 
 /* Begin PBXFileReference section */
 		8462832329B8C6A7004EFC9A /* TurboNavigator */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = TurboNavigator; path = ..; sourceTree = "<group>"; };
+		8462832629B90BB9004EFC9A /* ErrorPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
 		8484C2E529B132D20018596C /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8484C2E829B132D20018596C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8484C2EA29B132D20018596C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -57,11 +59,12 @@
 		8484C2E729B132D20018596C /* Demo */ = {
 			isa = PBXGroup;
 			children = (
+				8484C2F629B132D30018596C /* Info.plist */,
 				8484C2E829B132D20018596C /* AppDelegate.swift */,
+				8462832629B90BB9004EFC9A /* ErrorPresenter.swift */,
 				8484C2EA29B132D20018596C /* SceneDelegate.swift */,
 				8484C2F129B132D30018596C /* Assets.xcassets */,
 				8484C2F329B132D30018596C /* LaunchScreen.storyboard */,
-				8484C2F629B132D30018596C /* Info.plist */,
 			);
 			path = Demo;
 			sourceTree = "<group>";
@@ -158,6 +161,7 @@
 			files = (
 				8484C2E929B132D20018596C /* AppDelegate.swift in Sources */,
 				8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */,
+				8462832729B90BB9004EFC9A /* ErrorPresenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/Demo/ErrorPresenter.swift
+++ b/Demo/Demo/ErrorPresenter.swift
@@ -1,0 +1,116 @@
+import Turbo
+import UIKit
+
+protocol ErrorPresenter: UIViewController {
+    typealias Handler = () -> Void
+
+    func presentError(_ error: Error, handler: @escaping Handler)
+}
+
+/// Copied from the turbo-ios Demo project for this demo.
+extension ErrorPresenter {
+    func presentError(_ error: Error, handler: @escaping Handler) {
+        let errorViewController = ErrorViewController()
+        errorViewController.configure(with: error) { [unowned self] in
+            self.removeErrorViewController(errorViewController)
+            handler()
+        }
+
+        let errorView = errorViewController.view!
+        errorView.translatesAutoresizingMaskIntoConstraints = false
+
+        addChild(errorViewController)
+        view.addSubview(errorView)
+        NSLayoutConstraint.activate([
+            errorView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            errorView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            errorView.topAnchor.constraint(equalTo: view.topAnchor),
+            errorView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        errorViewController.didMove(toParent: self)
+    }
+
+    private func removeErrorViewController(_ errorViewController: UIViewController) {
+        errorViewController.willMove(toParent: nil)
+        errorViewController.view.removeFromSuperview()
+        errorViewController.removeFromParent()
+    }
+}
+
+final class ErrorViewController: UIViewController {
+    var handler: ErrorPresenter.Handler?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setup()
+    }
+
+    private func setup() {
+        view.backgroundColor = .systemBackground
+
+        let vStack = UIStackView(arrangedSubviews: [imageView, titleLabel, bodyLabel, button])
+        vStack.translatesAutoresizingMaskIntoConstraints = false
+        vStack.axis = .vertical
+        vStack.spacing = 16
+        vStack.alignment = .center
+
+        view.addSubview(vStack)
+        NSLayoutConstraint.activate([
+            vStack.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            vStack.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            vStack.leadingAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 32),
+            vStack.trailingAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -32),
+        ])
+    }
+
+    func configure(with error: Error, handler: @escaping ErrorPresenter.Handler) {
+        titleLabel.text = "Error loading page"
+        bodyLabel.text = error.localizedDescription
+        self.handler = handler
+    }
+
+    @objc func performAction(_ sender: UIButton) {
+        handler?()
+    }
+
+    // MARK: - Views
+
+    private let imageView: UIImageView = {
+        let configuration = UIImage.SymbolConfiguration(pointSize: 38, weight: .semibold)
+        let image = UIImage(systemName: "exclamationmark.triangle", withConfiguration: configuration)
+        let imageView = UIImageView(image: image)
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.preferredFont(forTextStyle: .largeTitle)
+        label.textAlignment = .center
+
+        return label
+    }()
+
+    private let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.preferredFont(forTextStyle: .body)
+        label.textAlignment = .center
+        label.numberOfLines = 0
+
+        return label
+    }()
+
+    private lazy var button: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("Retry", for: .normal)
+        button.addTarget(self, action: #selector(performAction(_:)), for: .touchUpInside)
+        button.titleLabel?.font = UIFont.boldSystemFont(ofSize: 17)
+
+        return button
+    }()
+}
+
+extension VisitableViewController: ErrorPresenter {}

--- a/Demo/Demo/ErrorPresenter.swift
+++ b/Demo/Demo/ErrorPresenter.swift
@@ -1,4 +1,3 @@
-import Turbo
 import UIKit
 
 protocol ErrorPresenter: UIViewController {
@@ -113,4 +112,4 @@ final class ErrorViewController: UIViewController {
     }()
 }
 
-extension VisitableViewController: ErrorPresenter {}
+extension UIViewController: ErrorPresenter {}

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -34,7 +34,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 }
 
 extension SceneDelegate: TurboNavigationDelegate {
-    func session(_ session: Turbo.Session, didFailRequestForVisitable visitable: Turbo.Visitable, error: Error) {
-        print("An error occurred loading a visit:", error)
+    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
+        if let errorPresenter = visitable as? ErrorPresenter {
+            errorPresenter.presentError(error) {
+                session.reload()
+            }
+        }
     }
 }

--- a/Demo/Server/app/views/navigations/show.html.erb
+++ b/Demo/Server/app/views/navigations/show.html.erb
@@ -48,4 +48,19 @@
       <i class="bi bi-chevron-right"></i>
     </div>
   <% end %>
+
+  <%= link_to "/not_found", class: "list-group-item list-group-item-action d-flex py-3" do %>
+    <div class="col flex-grow-0 flex-shrink-1 my-auto ps-1 pe-4">
+      <i class="bi bi-bug fs-1"></i>
+    </div>
+
+    <div class="w-100 mx-auto">
+      <p class="fs-5 mb-0">Error handling</p>
+      <p class="mb-0 text-muted">Visit a page that does not exist (404).</p>
+    </div>
+
+    <div class="col flex-grow-0 flex-shrink-1 my-auto">
+      <i class="bi bi-chevron-right"></i>
+    </div>
+  <% end %>
 </div>


### PR DESCRIPTION
This PR addresses #10 with an example on how to handle errors. It copies the `ErrorPresenter` code from turbo-ios to the demo project and adds a link to a route that doesn't exist, showing a 404 error.

Closes #10.