### PR TITLE
Clean up delegate and add option to customize `VisitableViewController`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## March 12, 2023
+
+* Option to customize `VisitableViewController`
+
+### Breaking changes
+
+* `TurboNavigationDelegate.shouldRoute(_:)` was removed
+* `TurboNavigationDelegate.customController(for:) -> UIViewController?`
+    * Renamed to `controller(_:forProposal:) -> UIViewController?`
+    * Returning `nil` now stops default navigation
+
 ## March 8, 2023
 
 * Rename project to Turbo Navigator

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ It shows off most of the navigation flows outlined above. There is also an examp
 
 ## Custom overrides
 
-You can also pass an optional delegate to `TurboNavigator` to handle custom routing.
+You can also implement an optional method on the `TurboNavigationDelegate` to handle custom routing.
 
 This is useful to break out of the default behavior and/or render a native screen.
 
@@ -199,22 +199,19 @@ This is useful to break out of the default behavior and/or render a native scree
 class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
 
-    func shouldRoute(_ proposal: VisitProposal) -> Bool {
-        if proposal.url.path.last == "sign_in" {
-            // Tell Turbo Navigator stop processing the request.
-            // Do something entirely custom with this link click.
-            return false
-        }
-        return true
-    }
-
-    func customController(for proposal: VisitProposal) -> UIViewController? {
-        if proposal.url.path.last == "numbers" {
+    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
+        if proposal.url.path == "/numbers" {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
+        } else if proposal.url.pathComponents.last == "cancel" {
+            // Return nil to tell Turbo Navigator stop processing the request.
+            return nil
+        } else {
+            // Return the given controller to continue with default behavior.
+            // Optionally customize the given controller.
+            controller.view.backgroundColor = .orange
+            return controller
         }
-        // Default behavior - Turbo Navigator routes a VisitableViewController.
-        return nil
     }
 }
 ```


### PR DESCRIPTION
This PR cleans up `TurboNavigationDelegate` to combine `shouldRoute(_:)` with `customController(for:)`.

Now, developers only have to implement `controller(_:forProposal:)`, as returning `nil` will stop Turbo Navigation from displaying a controller.

This also opens the option to customize the `VisitableViewController` before it is presented.