### PR TITLE
Option to customize the web view and configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## March 12, 2023
 
+* Option to customize web view and configuration
 * `Navigation` is now public
 * Option to customize `VisitableViewController`
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The `Demo/` directory includes an iOS app and Ruby on Rails server to demo the p
 
 It shows off most of the navigation flows outlined above. There is also an example CRUD resource for more real world applications of each.
 
-## Custom overrides
+## Custom controller and routing overrides
 
 You can also implement an optional method on the `TurboNavigationDelegate` to handle custom routing.
 
@@ -203,7 +203,7 @@ class MyCustomClass: TurboNavigationDelegate {
         if proposal.url.path == "/numbers" {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
-        } else if proposal.url.pathComponents.last == "cancel" {
+        } else if proposal.presentation == .clearAll {
             // Return nil to tell Turbo Navigator stop processing the request.
             return nil
         } else {
@@ -213,5 +213,35 @@ class MyCustomClass: TurboNavigationDelegate {
             return controller
         }
     }
+}
+```
+
+## Custom configuration
+
+Customize the configuration via `TurboConfig`.
+
+### Override the user agent
+
+Keep "Turbo Native" to use `turbo_native_app?` on your Rails server.
+
+```swift
+TurboConfig.shared.userAgent = "Custom (Turbo Native)"
+```
+
+### Customize the web view and web view configuration
+
+A block is used because a new instance is needed for each web view.
+
+Don't forget to set user agent and use a shared process pool on the configuration.
+
+```swift
+TurboConfig.shared.makeCustomWebView = {
+    let configuration = WKWebViewConfiguration()
+    // Customize configuration.
+
+    let webView = WKWebView(frame: .zero, configuration: configuration)
+    // Customize web view.
+
+    return webView
 }
 ```

--- a/Sources/TurboNavigator/TurboConfig.swift
+++ b/Sources/TurboNavigator/TurboConfig.swift
@@ -1,19 +1,22 @@
 import WebKit
 
 public class TurboConfig {
+    public typealias WebViewBlock = () -> WKWebView
+
     public static let shared = TurboConfig()
 
     /// Override to set a custom user agent.
     /// Include "Turbo Native" to use `turbo_native_app?` on your Rails server.
     public var userAgent = "Turbo Native iOS"
 
+    /// Optionally customize the web views used by each Turbo Session.
+    /// Ensure you return a new instance each time.
+    public var makeCustomWebView: WebViewBlock?
+
     // MARK: - Internal
 
     func makeWebView() -> WKWebView {
-        let configuration = WKWebViewConfiguration()
-        configuration.applicationNameForUserAgent = userAgent
-        configuration.processPool = sharedProcessPool
-        return WKWebView(frame: .zero, configuration: configuration)
+        makeCustomWebView?() ?? WKWebView(frame: .zero, configuration: makeWebViewConfiguration())
     }
 
     // MARK: - Private
@@ -21,4 +24,12 @@ public class TurboConfig {
     private let sharedProcessPool = WKProcessPool()
 
     private init() {}
+
+    // A method (not a property) because we need a new instance for each web view.
+    private func makeWebViewConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.applicationNameForUserAgent = userAgent
+        configuration.processPool = sharedProcessPool
+        return configuration
+    }
 }


### PR DESCRIPTION
Customizing the web view is useful for disabling link previews:

```swift
webView.allowsLinkPreviews = false
```

And customizing the web view configuration is necessary to add script message handlers (the JavaScript bridge):

```swift
webViewConfiguration.userContentController = CustomScriptMessageHandler()
```

See the README for documentation. Closes #6.