### PR TITLE
Handle external URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## March 12, 2023
 
+* External URLs are presented via `SFSafariViewController` but can be customized
 * Option to customize web view and configuration
 * `Navigation` is now public
 * Option to customize `VisitableViewController`

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -42,9 +42,9 @@
 			isa = PBXGroup;
 			children = (
 				8484C2E729B132D20018596C /* Demo */,
+				8484C2FE29B133880018596C /* Frameworks */,
 				8484C2FC29B132E90018596C /* Packages */,
 				8484C2E629B132D20018596C /* Products */,
-				8484C2FE29B133880018596C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};

--- a/Demo/Server/app/views/dashboards/show.html.erb
+++ b/Demo/Server/app/views/dashboards/show.html.erb
@@ -21,4 +21,7 @@
     description: "Present a modal screen." %>
 </div>
 
-<%= link_to "CRUD example", resources_path, class: "btn btn-outline-primary w-100 mt-5" %>
+<div class="d-flex gap-2 justify-content-sm-center mt-5">
+  <%= link_to "CRUD example", resources_path, class: "btn btn-outline-primary w-100" %>
+  <%= link_to "Documentation", "https://github.com/joemasilotti/TurboNavigator/blob/main/README.md", class: "btn btn-outline-primary w-100" %>
+</div>

--- a/README.md
+++ b/README.md
@@ -245,3 +245,18 @@ TurboConfig.shared.makeCustomWebView = {
     return webView
 }
 ```
+
+### Customize behavior for external URLs
+
+Turbo cannot navigate across domains because page visits are done via JavaScript. A clicked link that points to a different domain is considered external.
+
+By default, a `SFSafariViewController` is presented. This can be overridden by implementing the following delegate method.
+
+```swift
+class MyCustomClass: TurboNavigationDelegate {
+    func openExternalURL(_ url: URL, from controller: UIViewController) {
+        // Do something custom with the external URL.
+        // The controller is provided to present on top of.
+    }
+}
+```

--- a/Sources/TurboNavigator/TurboNavigator.swift
+++ b/Sources/TurboNavigator/TurboNavigator.swift
@@ -1,3 +1,4 @@
+import SafariServices
 import Turbo
 import UIKit
 import WebKit
@@ -5,18 +6,31 @@ import WebKit
 /// Implement to be notified when certain navigations are performed
 /// or to render a native controller instead of a Turbo web visit.
 public protocol TurboNavigationDelegate: AnyObject {
-    /// Implement to override or customize the controller to be displayed.
-    /// Return `nil` to not display or route anything.
-    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController?
-
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by calling `session.reload()`.
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
+
+    /// Optional. Implement to override or customize the controller to be displayed.
+    /// Return `nil` to not display or route anything.
+    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController?
+
+    /// Optional. Implement to customize handling of external URLs.
+    /// If not implemented, will present `SFSafariViewController` as a modal and load the URL.
+    func openExternalURL(_ url: URL, from controller: UIViewController)
 }
 
 public extension TurboNavigationDelegate {
     func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
         VisitableViewController(url: proposal.url)
+    }
+
+    func openExternalURL(_ url: URL, from controller: UIViewController) {
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            safariViewController.preferredControlTintColor = .tintColor
+        }
+        controller.present(safariViewController, animated: true)
     }
 }
 
@@ -213,6 +227,11 @@ extension TurboNavigator: SessionDelegate {
         if session == modalSession {
             self.session.clearSnapshotCache()
         }
+    }
+
+    public func session(_ session: Session, openExternalURL url: URL) {
+        let controller = session === modalSession ? modalNavigationController : navigationController
+        delegate?.openExternalURL(url, from: controller)
     }
 
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {

--- a/Sources/TurboNavigator/TurboNavigator.swift
+++ b/Sources/TurboNavigator/TurboNavigator.swift
@@ -209,6 +209,12 @@ extension TurboNavigator: SessionDelegate {
         route(proposal)
     }
 
+    public func sessionDidFinishFormSubmission(_ session: Session) {
+        if session == modalSession {
+            self.session.clearSnapshotCache()
+        }
+    }
+
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
         delegate?.session(session, didFailRequestForVisitable: visitable, error: error)
     }

--- a/Sources/TurboNavigator/TurboNavigator.swift
+++ b/Sources/TurboNavigator/TurboNavigator.swift
@@ -37,6 +37,8 @@ public class TurboNavigator {
     }
 
     public var rootViewController: UIViewController { navigationController }
+    public let navigationController: UINavigationController
+    public let modalNavigationController: UINavigationController
 
     public func route(_ url: URL) {
         let options = VisitOptions(action: .advance, response: nil)
@@ -77,8 +79,6 @@ public class TurboNavigator {
     }
 
     private weak var delegate: TurboNavigationDelegate?
-    private let navigationController: UINavigationController
-    private let modalNavigationController: UINavigationController
 
     private func controller(for proposal: VisitProposal) -> UIViewController? {
         let defaultController = VisitableViewController(url: proposal.url)


### PR DESCRIPTION
By default, an instance of `SFSafariViewController` is presented as a modal. Implement the new delegate method `openExternalURL(_:from:)` to customize the behavior.