### PR TITLE
start a cookbook section in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,15 +261,13 @@ class MyCustomClass: TurboNavigationDelegate {
 }
 ```
 
-## Cookbook
+## How to guides
 
 - [How to add new properties to path configuration rules](#how-to-add-new-properties-to-path-configuration-rules)
-- [How to display a full-screen modal](#how-to-display-a-full-screen-modal)
-- [How to display a full-screen modal and remove the "close" button](#how-to-display-a-full-screen-modal-and-remove-the-close-button)
 
 ### How to add new properties to path configuration rules
 
-Here is what a typical rule looks like:
+A rule in the Path Configuration typically looks like this:
 
 ```json
 {
@@ -277,18 +275,13 @@ Here is what a typical rule looks like:
   "properties": {
     "context": "modal"
   },
-  "comment": "Present the web login screen in a modal"
+  "comment": "Present the web login screen in a modal."
 }
 ```
 
-By default, the `properties` property can take the following two configuration options:
+By default, the `properties` property can take the following two configuration options, `context` and `presentation`. See [Navigation.swift](https://github.com/joemasilotti/TurboNavigator/blob/main/Sources/TurboNavigator/Navigation.swift) for possible values.
 
-- `context`
-- `presentation`
-
-The permitted values for each are defined here: [Navigation.swift](https://github.com/joemasilotti/TurboNavigator/blob/main/Sources/TurboNavigator/Navigation.swift)
-
-Let's say we wanted to use specific view controllers for certain routes. We might want to add a new `controller` property.
+Indicate that a custom view controller should be used with a new `controller` property on the rule.
 
 ```json
 {
@@ -301,15 +294,14 @@ Let's say we wanted to use specific view controllers for certain routes. We migh
 }
 ```
 
-Now that we added this new property to the path configuration, we should extend the `VisitProposal` struct to give it type-safe access.
-
-1. Let's start by creating a new `enum` for it.
+Increase type safety and reduce the use of magic strings by extending `VisitProposal`. First, extend `Navigation` with a new enum, `Controller`.
 
 ```swift
 // NavigationExtension.swift
+
 import TurboNavigator
 
-enum Navigation {
+extension Navigation {
     enum Controller: String {
         case `default`
         case newSession = "new_session"
@@ -320,10 +312,11 @@ enum Navigation {
 }
 ```
 
-2. Then let's extend the `VisitProposal`
+Then extend `VisitProposal` to convert a raw string from the Path Configuration to the new enum.
 
 ```swift
 // VisitProposalExtension.swift
+
 import Turbo
 
 extension VisitProposal {
@@ -336,122 +329,14 @@ extension VisitProposal {
 }
 ```
 
-3. You can now access the new property. Here is an example:
+Use this new property to return a custom view controller in the `TurboNavigationDelegate` implementation.
 
 ```swift
-func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
-  if proposal.controller == .newSession {
-    // ... return a custom native view controller
-  }
-}
-```
-
-### How to display a full-screen modal
-
-By default, modals use "pageSheet" presentation, occupying a 3rd of the screen and allowing swipe-down dismissal. To display a full-screen modal, add an option to your path configuration and set the presentation style within the `controller` function. This function can be used to configure the modal presentation for a specific route before returning the controller.
-
-1. Add a new property to the path configuration
-
-```json
-{
-  "patterns": ["/very_long_form/new"],
-  "properties": {
-    "context": "modal",
-    "modalPresentationStyle": "full_screen"
-  },
-  "comment": "Present the very long form in a full-screen modal"
-}
-```
-
-2. Configure access to the `modalPresentationStyle` on the `VisitProposal`:
-
-```swift
-// NavigationExtension.swift
-import TurboNavigator
-
-extension Navigation {
-  enum ModalPresentationStyle: String {
-    case `default`
-    case fullScreen = "full_screen"
-  }
-}
-// VisitProposalExtension.swift
-import Turbo
-
-extension VisitProposal {
-  var modalPresentationStyle: Navigation.ModalPresentationStyle {
-    if let rawValue = properties["modalPresentationStyle"] as? String {
-      return Navigation.ModalPresentationStyle(rawValue: rawValue) ?? .default
-    }
-    return .default
-  }
-}
-```
-
-3. Set the `modalNavigationController.modalPresentationStyle` based on the path configuration.
-
-```swift
-extension TurboTabBarController: TurboNavigationDelegate {
+class MyCustomClass: TurboNavigationDelegate {
     func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
-        modalNavigationController.modalPresentationStyle = {
-        switch proposal.modalPresentationStyle {
-        case .fullScreen:
-          return UIModalPresentationStyle.fullScreen
-        case .default:
-          return UIModalPresentationStyle.automatic
+        if proposal.controller == .newSession {
+            return NewSessionViewController()
         }
-      }()
-
-      return controller
-    }
-}
-```
-
-### How to display a full-screen modal and remove the "close" button
-
-The native modal shows a "Done" button in the top left corner. If you want to prevent the user from dismissing the modal, you can set the `isNavigationBarHidden` property on the `modalNavigationController`.
-
-Here is an example of how you would configure this through the path configuration.
-
-1. Add a new property to the path configuration
-
-```json
-{
-  "patterns": ["/users/sign_in"],
-  "properties": {
-    "context": "modal",
-    "modalPresentationStyle": "full_screen",
-    "isModalNavigationBarHidden": true
-  },
-  "comment": "Present the login screen in full-screen modal that cannot be dismissed"
-}
-```
-
-2. Configure access to the `modalPresentationStyle` on the `VisitProposal`:
-
-```swift
-// VisitProposalExtension.swift
-import Turbo
-
-extension VisitProposal {
-  var isModalNavigationBarHidden: Bool {
-    if let value = properties["isModalNavigationBarHidden"] as? Bool {
-      return value
-    }
-    return false
-  }
-}
-```
-
-3. Set the `modalNavigationController.modalPresentationStyle` based on the path configuration.
-
-```swift
-extension TurboTabBarController: TurboNavigationDelegate {
-    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
-
-      modalNavigationController.isNavigationBarHidden = proposal.isModalNavigationBarHidden
-
-      return controller
     }
 }
 ```


### PR DESCRIPTION
In this PR, I wanted to add instructions for 2 uses cases:

1. Show the modal in a "full-screen" presentation style.
2. Remove the "Done" button on the modal to prevent users from dismissing it

In order to achieve this cleanly, it is good to extend the `VisitProposal` struct, so I also included that in the instructions.

@joemasilotti The approach I outlined in the cookbook differs a little bit from the one you showed me here: https://github.com/joemasilotti/TurboNavigator/issues/19

The code you shared with me shows how to accomplish the modal presentation style based on which native ViewController will be presented but I thought it would be good to have a way of configuring the modal presentation style based solely on a configuration option such as `modalPresentationStyle`.

Please let me know if these instructions are correct. I am happy to keep editing them until they are!

Thank you Joe!

PS: After this is merged, I am thinking another "cookbook" entry could be "How to disable pull to refresh for certain routes"