### PR TITLE
Always present an `UIAlertController` alone

### DIFF
--- a/Sources/TurboNavigator/TurboNavigator.swift
+++ b/Sources/TurboNavigator/TurboNavigator.swift
@@ -64,19 +64,23 @@ public class TurboNavigator {
     public func route(_ proposal: VisitProposal) {
         guard let controller = controller(for: proposal) else { return }
 
-        switch proposal.presentation {
-        case .default:
-            navigate(with: controller, via: proposal)
-        case .pop:
-            pop()
-        case .replace:
-            replace(with: controller, via: proposal)
-        case .refresh:
-            refresh()
-        case .clearAll:
-            clearAll()
-        case .replaceRoot:
-            replaceRoot(with: controller)
+        if let alert = controller as? UIAlertController {
+            presentAlert(alert)
+        } else {
+            switch proposal.presentation {
+            case .default:
+                navigate(with: controller, via: proposal)
+            case .pop:
+                pop()
+            case .replace:
+                replace(with: controller, via: proposal)
+            case .refresh:
+                refresh()
+            case .clearAll:
+                clearAll()
+            case .replaceRoot:
+                replaceRoot(with: controller)
+            }
         }
     }
 
@@ -100,6 +104,14 @@ public class TurboNavigator {
 
         // Developer can return nil from this method to break out of navigation.
         return delegate.controller(defaultController, forProposal: proposal)
+    }
+
+    private func presentAlert(_ alert: UIAlertController) {
+        if navigationController.presentedViewController != nil {
+            modalNavigationController.present(alert, animated: true)
+        } else {
+            navigationController.present(alert, animated: true)
+        }
     }
 
     private func navigate(with controller: UIViewController, via proposal: VisitProposal) {

--- a/Tests/TurboNavigatorTests/TestableNavigationController.swift
+++ b/Tests/TurboNavigatorTests/TestableNavigationController.swift
@@ -2,10 +2,12 @@ import UIKit
 
 /// Manipulate a navigation controller under test.
 /// Ensures `viewControllers` is updated synchronously.
-/// Use `dismissWasCalled` instead of checking if `presentedViewController` is nil.
+/// Manages `presentedViewController` directly because it isn't updated on the same thread.
 class TestableNavigationController: UINavigationController {
-    /// Use instead of checking if `presentedViewController` is nil.
-    private(set) var dismissWasCalled = false
+    override var presentedViewController: UIViewController? {
+        get { _presentedViewController }
+        set { _presentedViewController = newValue }
+    }
 
     override func pushViewController(_ viewController: UIViewController, animated: Bool) {
         super.pushViewController(viewController, animated: false)
@@ -24,12 +26,16 @@ class TestableNavigationController: UINavigationController {
     }
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        _presentedViewController = viewControllerToPresent
         super.present(viewControllerToPresent, animated: false, completion: completion)
     }
 
     override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-        // Even dismissing without animation doesn't correctly set presentedViewController to nil.
-        dismissWasCalled = true
+        _presentedViewController = nil
         super.dismiss(animated: false, completion: completion)
     }
+
+    // MARK: Private
+
+    private var _presentedViewController: UIViewController?
 }

--- a/Tests/TurboNavigatorTests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests/TurboNavigatorTests.swift
@@ -3,7 +3,7 @@ import Turbo
 import XCTest
 
 /// Tests are written in the following format:
-/// test_currentContext_givenContext_givenPresentation_modifiers_result()
+/// `test_currentContext_givenContext_givenPresentation_modifiers_result()`
 /// See the README for a more visually pleasing table.
 final class TurboNavigatorTests: XCTestCase {
     override func setUp() {
@@ -106,7 +106,7 @@ final class TurboNavigatorTests: XCTestCase {
 
         let proposal = VisitProposal()
         navigator.route(proposal)
-        XCTAssert(navigationController.dismissWasCalled)
+        XCTAssertNil(navigationController.presentedViewController)
         XCTAssert(navigationController.viewControllers.last is VisitableViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
         assertVisited(url: proposal.url, on: .main)
@@ -118,7 +118,7 @@ final class TurboNavigatorTests: XCTestCase {
 
         let proposal = VisitProposal(presentation: .replace)
         navigator.route(proposal)
-        XCTAssert(navigationController.dismissWasCalled)
+        XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
         assertVisited(url: proposal.url, on: .main)
@@ -171,7 +171,7 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertEqual(modalNavigationController.viewControllers.count, 2)
 
         navigator.route(VisitProposal(presentation: .pop))
-        XCTAssertFalse(navigationController.dismissWasCalled)
+        XCTAssertNotNil(navigationController.presentedViewController)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
     }
 
@@ -180,7 +180,7 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
 
         navigator.route(VisitProposal(presentation: .pop))
-        XCTAssertTrue(navigationController.dismissWasCalled)
+        XCTAssertNil(navigationController.presentedViewController)
     }
 
     func test_any_any_clearAll_dismissesModalThenPopsToRootOnMainStack() {
@@ -190,7 +190,7 @@ final class TurboNavigatorTests: XCTestCase {
 
         let proposal = VisitProposal(presentation: .clearAll)
         navigator.route(proposal)
-        XCTAssertTrue(navigationController.dismissWasCalled)
+        XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers, [rootController])
     }
 
@@ -200,7 +200,7 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 3)
 
         navigator.route(VisitProposal(presentation: .replaceRoot))
-        XCTAssertTrue(navigationController.dismissWasCalled)
+        XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssert(navigationController.viewControllers.last is VisitableViewController)
     }

--- a/Tests/TurboNavigatorTests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests/TurboNavigatorTests.swift
@@ -205,6 +205,33 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssert(navigationController.viewControllers.last is VisitableViewController)
     }
 
+    func test_presentingUIAlertController_doesNotWrapInNavigationController() {
+        let alertControllerDelegate = AlertControllerDelegate()
+        navigator = TurboNavigator(
+            delegate: alertControllerDelegate,
+            navigationController: navigationController,
+            modalNavigationController: modalNavigationController
+        )
+
+        navigator.route(VisitProposal(path: "/alert"))
+
+        XCTAssert(navigationController.presentedViewController is UIAlertController)
+    }
+
+    func test_presentingUIAlertController_onTheModal_doesNotWrapInNavigationController() {
+        let alertControllerDelegate = AlertControllerDelegate()
+        navigator = TurboNavigator(
+            delegate: alertControllerDelegate,
+            navigationController: navigationController,
+            modalNavigationController: modalNavigationController
+        )
+
+        navigator.route(VisitProposal(context: .modal))
+        navigator.route(VisitProposal(path: "/alert"))
+
+        XCTAssert(modalNavigationController.presentedViewController is UIAlertController)
+    }
+
     // MARK: Private
 
     private enum Context {
@@ -257,4 +284,17 @@ private extension VisitProposal {
         ]
         self.init(url: url, options: options, properties: properties)
     }
+}
+
+// MARK: - AlertControllerDelegate
+
+private class AlertControllerDelegate: TurboNavigationDelegate {
+    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
+        if proposal.url.path == "/alert" {
+            return UIAlertController(title: "Alert", message: nil, preferredStyle: .alert)
+        }
+        return controller
+    }
+
+    func session(_ session: Turbo.Session, didFailRequestForVisitable visitable: Turbo.Visitable, error: Error) {}
 }


### PR DESCRIPTION
Without this code, if a developer returned an instance of `UIAlertController` as a custom controller then Turbo Navigator would wrap it in a `UINavigationController`. Which leads to some weird UI issues.

This PR instead presents the alert alone.