### PR TITLE
Modal presentation style

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "TurboNavigator",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v14),
     ],
     products: [
         .library(

--- a/Sources/TurboNavigator/Navigation.swift
+++ b/Sources/TurboNavigator/Navigation.swift
@@ -12,4 +12,9 @@ public enum Navigation {
         case clearAll = "clear_all"
         case replaceRoot = "replace_root"
     }
+
+    public enum Modal: String {
+        case `default`
+        case fullScreen = "full_screen"
+    }
 }

--- a/Sources/TurboNavigator/TurboNavigator.swift
+++ b/Sources/TurboNavigator/TurboNavigator.swift
@@ -112,6 +112,7 @@ public class TurboNavigator {
             if navigationController.presentedViewController != nil {
                 pushOrReplace(on: modalNavigationController, with: controller, via: proposal)
             } else {
+                modalNavigationController.modalPresentationStyle = proposal.modalPresentationStyle
                 modalNavigationController.setViewControllers([controller], animated: false)
                 navigationController.present(modalNavigationController, animated: true)
             }
@@ -172,6 +173,7 @@ public class TurboNavigator {
             if navigationController.presentedViewController != nil {
                 modalNavigationController.replaceLastViewController(with: controller)
             } else {
+                modalNavigationController.modalPresentationStyle = proposal.modalPresentationStyle
                 modalNavigationController.setViewControllers([controller], animated: false)
                 navigationController.present(modalNavigationController, animated: true)
             }

--- a/Sources/TurboNavigator/VisitProposalExtension.swift
+++ b/Sources/TurboNavigator/VisitProposalExtension.swift
@@ -15,4 +15,20 @@ public extension VisitProposal {
         }
         return .default
     }
+
+    var modalPresentationStyle: UIModalPresentationStyle {
+        if let rawValue = properties["modal"] as? String {
+            return Navigation.Modal(rawValue: rawValue)?.asModalPresentationStyle ?? .automatic
+        }
+        return .automatic
+    }
+}
+
+private extension Navigation.Modal {
+    var asModalPresentationStyle: UIModalPresentationStyle {
+        switch self {
+            case .default: return .automatic
+            case .fullScreen: return .fullScreen
+        }
+    }
 }


### PR DESCRIPTION
This PR handles modal presentation via Path Configuration. The following rule will present a _full screen_ modal.

```json
{
  "patterns": [
    "/users/sign_in"
  ],
  "properties": {
    "context": "modal",
    "modal": "full_screen"
  }
}
```

Any other value for `modal`, including a missing key, will use the default/automatic behavior.

I still need to add documentation and tests for this before merging it in.