### PR TITLE
Fix typo in Path Configuration rule example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ To present forms (URLs ending in `/new` or `/edit`) as a modal, add the followin
 {
   "patterns": [
     "/new$",
-    "/edi$"
+    "/edit$"
   ],
   "properties": {
     "context": "modal"


### PR DESCRIPTION
tiny typo fix for `/edit$` path in readme