### PR TITLE
add sessionDidLoadWebView to TurboNavigationDelegate

### DIFF
--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -23,7 +23,8 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Optional. Implement to handle when the web view process dies and can't be restored.
     func sessionWebViewProcessDidTerminate(_ session: Session)
 
-    /// Optional. Implement if you need to change the naviagation delegate on the webView (https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate)
+    /// Optional. Implement to become the web view's navigation delegate after the initial cold boot visit is completed.
+    /// https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate
     func sessionDidLoadWebView(_ session: Session)
 }
 

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -22,6 +22,9 @@ public protocol TurboNavigationDelegate: AnyObject {
 
     /// Optional. Implement to handle when the web view process dies and can't be restored.
     func sessionWebViewProcessDidTerminate(_ session: Session)
+
+    /// Optional. Implement if you need to change the naviagation delegate on the webView (https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate)
+    func sessionDidLoadWebView(_ session: Session)
 }
 
 public extension TurboNavigationDelegate {
@@ -41,6 +44,8 @@ public extension TurboNavigationDelegate {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
+
+    func sessionDidLoadWebView(_ session: Session) {}
 
     func sessionWebViewProcessDidTerminate(_ session: Session) {}
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -226,4 +226,8 @@ extension TurboNavigator: SessionDelegate {
     public func session(_ session: Session, didReceiveAuthenticationChallenge challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         delegate?.didReceiveAuthenticationChallenge(challenge, completionHandler: completionHandler)
     }
+
+    public func sessionDidLoadWebView(_ session: Session) {
+        delegate?.sessionDidLoadWebView(session)
+    }
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -228,6 +228,7 @@ extension TurboNavigator: SessionDelegate {
     }
 
     public func sessionDidLoadWebView(_ session: Session) {
+        session.webView.navigationDelegate = session
         delegate?.sessionDidLoadWebView(session)
     }
 }


### PR DESCRIPTION
Hi @joemasilotti, 

I am implementing some functionality which requires me to set the navigation delegate of the web view.
According to the Turbo docs, the way to do this is to implement the `sessionDidLoadWebView` method.

https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate

> When doing the cold boot visit, Turbo will need to take over as the WKWebView’s navigationDelegate to know when the page loads. After that, it's likely your application will want to become the navigationDelegate so you can have full control over the various methods.

I added `sessionDidLoadWebView` to the `TurboNavigationDelegate` in my fork, and I would like to know if this is something you would merge into `TurboNavigator`.

If these changes are not suitable, please let me know if there is an alternative way of becoming the web view's navigation delegate.

Thank you!