### PR TITLE
Implement `/resume_historical_location` to perform no action

### DIFF
--- a/Demo/Server/app/controllers/configurations_controller.rb
+++ b/Demo/Server/app/controllers/configurations_controller.rb
@@ -23,12 +23,12 @@ class ConfigurationsController < ApplicationController
         },
         {
           patterns: [
-            "/refresh_historical_location"
+            "/resume_historical_location"
           ],
           properties: {
-            presentation: "refresh"
+            presentation: "none"
           },
-          comment: "Dismiss a modal or pop a controller then refresh with `refresh_or_redirect_to` via turbo-rails."
+          comment: "Skip navigation with `resume_or_redirect_to` via turbo-rails."
         },
         {
           patterns: [

--- a/Demo/Server/app/views/navigations/show.html.erb
+++ b/Demo/Server/app/views/navigations/show.html.erb
@@ -24,6 +24,12 @@
     description: "Pop this screen off the stack." %>
 
   <%= render "navigations/item",
+    path: turbo_resume_historical_location_path,
+    icon: "bi-sign-stop",
+    name: "Resume navigation",
+    description: "Do nothing." %>
+
+  <%= render "navigations/item",
     path: "/not_found",
     icon: "bi-bug",
     name: "Error handling",

--- a/Sources/Navigation.swift
+++ b/Sources/Navigation.swift
@@ -11,5 +11,6 @@ public enum Navigation {
         case refresh
         case clearAll = "clear_all"
         case replaceRoot = "replace_root"
+        case none
     }
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -49,6 +49,8 @@ public class TurboNavigator {
                 clearAll()
             case .replaceRoot:
                 replaceRoot(with: controller)
+            case .none:
+                break // Do nothing.
             }
         }
     }


### PR DESCRIPTION
According to Android:

1. [`/custom/resume` -> `presentation: "none"`](https://github.com/hotwired/turbo-android/blob/c450cecc29d70eb2d6f935498b24777f89277996/turbo/src/main/assets/json/test-configuration.json#L72-L77)
1. [`TurboNavMode.NONE` -> Do nothing](https://github.com/hotwired/turbo-android/blob/c450cecc29d70eb2d6f935498b24777f89277996/turbo/src/main/kotlin/dev/hotwire/turbo/nav/TurboNavigator.kt#L80)

Fixes #36