### PR TITLE
Add Javascript alert functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,24 @@ class MyCustomClass: TurboNavigationDelegate {
     }
 }
 ```
+
+### Customize behavior for Javascript Alert()
+
+If you have a web view that uses `alert()` or `confirm()`, you need to implement the following method which sets up the `WKUIDelegate`.
+
+This will only work if you have made `Session` conform to `WKUIDelegate`.
+
+```swift
+extension Session: WKUIDelegate {
+  //Implement different methods here to handle alerts, etc.
+}
+```
+You must call this function in the SceneDelegate' to set setup this behavior.
+
+Found in the `TurboNavigator` class:
+```swift
+    public func setupSessionWebViewUIDelegate() {
+        self.session.webView.uiDelegate = self.session as? WKUIDelegate
+        self.modalSession.webView.uiDelegate = self.modalSession as? WKUIDelegate
+    }
+```

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -52,6 +52,11 @@ public class TurboNavigator {
             }
         }
     }
+    
+    public func setupSessionWebViewUIDelegate() {
+        self.session.webView.uiDelegate = self.session as? WKUIDelegate
+        self.modalSession.webView.uiDelegate = self.modalSession as? WKUIDelegate
+    }
 
     // MARK: Internal
 


### PR DESCRIPTION
The aim of this PR is to enable a session's webview to be able to react to web javascript alerts and show native alerts as proposed in the turbo-ios repo.  

I realize that by design we might not want to expose the session outside of the `TurboNavigator` class and perhaps there is a better way to achieve this I am open to new ideas!