### PR TITLE
Pass pre-built `WKWebView` instance to `makeCustomWebView`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,19 +230,14 @@ TurboConfig.shared.userAgent = "Custom (Turbo Native)"
 
 ### Customize the web view and web view configuration
 
-A block is used because a new instance is needed for each web view.
-
-Don't forget to set user agent and use a shared process pool on the configuration.
+A closure is used because a new instance is needed for each web view. The closure has a `WKWebViewConfiguration` argument that's pre-built and ready to be customized and assigned to a new web view.
 
 ```swift
-TurboConfig.shared.makeCustomWebView = {
-    let configuration = WKWebViewConfiguration()
-    // Customize configuration.
+TurboConfig.shared.makeCustomWebView = { (configuration: WKWebViewConfiguration) in
+    // Customize the WKWebViewConfiguration instance
+    // ...
 
-    let webView = WKWebView(frame: .zero, configuration: configuration)
-    // Customize web view.
-
-    return webView
+    return WKWebView(frame: .zero, configuration: configuration)
 }
 ```
 

--- a/Sources/TurboConfig.swift
+++ b/Sources/TurboConfig.swift
@@ -1,7 +1,7 @@
 import WebKit
 
 public class TurboConfig {
-    public typealias WebViewBlock = () -> WKWebView
+    public typealias WebViewBlock = (_ configuration: WKWebViewConfiguration) -> WKWebView
 
     public static let shared = TurboConfig()
 
@@ -11,12 +11,14 @@ public class TurboConfig {
 
     /// Optionally customize the web views used by each Turbo Session.
     /// Ensure you return a new instance each time.
-    public var makeCustomWebView: WebViewBlock?
+    public var makeCustomWebView: WebViewBlock = { (configuration: WKWebViewConfiguration) in
+        WKWebView(frame: .zero, configuration: configuration)
+    }
 
     // MARK: - Internal
 
     func makeWebView() -> WKWebView {
-        makeCustomWebView?() ?? WKWebView(frame: .zero, configuration: makeWebViewConfiguration())
+        makeCustomWebView(makeWebViewConfiguration())
     }
 
     // MARK: - Private


### PR DESCRIPTION
Instead of forcing applications to make an all-or-nothing decision on whether or not they use the pre-built `WKWebView` provided by the package or roll their own, this commit introduces a mechanism for applications to _either_ configure the pre-built instance or built a fresh instance of their own.