### PR TITLE
Expand `TurboNavigationDelegate` to support loading Session's Web View

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,27 @@ Keep "Turbo Native" to use `turbo_native_app?` on your Rails server.
 TurboConfig.shared.userAgent = "Custom (Turbo Native)"
 ```
 
+### Access the web view
+
+Access the `WKWebView` instance when it gets loaded by the `Session`.
+
+Being able to access the `WebView` when it's loaded might be useful to your
+application. For example, you can attach a
+
+```swift
+class MyCustomClass: TurboNavigationDelegate, NSObject, WKScriptMessageHandler {
+    let navigator = TurboNavigator(delegate: self)
+
+    func session(_ session: Session, didLoadWebView webView: WKWebView) {
+        webView.configuration.userContentController.add(self, name: "myNativeApp")
+    }
+
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage ) {
+        // handle the JavaScript Object message
+    }
+}
+```
+
 ### Customize the web view and web view configuration
 
 A block is used because a new instance is needed for each web view.

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -5,6 +5,9 @@ import WebKit
 /// Implement to be notified when certain navigations are performed
 /// or to render a native controller instead of a Turbo web visit.
 public protocol TurboNavigationDelegate: AnyObject {
+    /// Configure the Session's WKWebView when it's loaded
+    func session(_ session: Session, didLoadWebView webView: WKWebView)
+
     /// An error occurred loading the request, present it to the user.
     /// Retry the request by calling `session.reload()`.
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
@@ -25,6 +28,8 @@ public protocol TurboNavigationDelegate: AnyObject {
 }
 
 public extension TurboNavigationDelegate {
+    func session(_ session: Session, didLoadWebView webView: WKWebView) {}
+    
     func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
         VisitableViewController(url: proposal.url)
     }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -200,6 +200,11 @@ public class TurboNavigator {
 // MARK: - SessionDelegate
 
 extension TurboNavigator: SessionDelegate {
+    public func sessionDidLoadWebView(_ session: Session) {
+        super.sessionDidLoadWebView(session)
+        delegate?.session(session, didLoadWebView: session.webView)
+    }
+
     public func session(_ session: Session, didProposeVisit proposal: VisitProposal) {
         route(proposal)
     }


### PR DESCRIPTION
Access the `WKWebView` instance when it gets loaded by the `Session`.

Being able to access the `WebView` when it's loaded might be useful to your application. For example, you can attach a

```swift
class MyCustomClass: TurboNavigationDelegate, NSObject, WKScriptMessageHandler {
    let navigator = TurboNavigator(delegate: self)

    func session(_ session: Session, didLoadWebView webView: WKWebView) {
        webView.configuration.userContentController.add(self, name: "myNativeApp")
    }

    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage ) {
        // handle the JavaScript Object message
    }
}
```

With the `session` and `modalSession` properties marked with `internal` access, application's are forced to construct their own `WKWebView` instances by setting `TurboConfig.shared.makeCustomWebView`.

By expanding the `TurboNavigationDelegate` protocol to notify delegates when the `WKWebView` is loaded, it exposes _both_ the `Session` instance _and_ the `WKWebView` instance.