### PR TITLE
Automatic error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Pass a configuration to the web view create block by @seanpdoyle [#41](https://github.com/joemasilotti/TurboNavigator/pull/41)
 * Option to override `sessionDidLoadWebView(_:)` by @yanshiyason [#35](https://github.com/joemasilotti/TurboNavigator/pull/35)
 * Handle `/resume_historical_location` route [#38](https://github.com/joemasilotti/TurboNavigator/pull/38)
+* Automatically handle errors with option to override [#45](https://github.com/joemasilotti/TurboNavigator/pull/45)
 
 ### Breaking changes
 

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -306,6 +306,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -335,6 +336,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		8462832529B8C6B5004EFC9A /* TurboNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 8462832429B8C6B5004EFC9A /* TurboNavigator */; };
-		8462832729B90BB9004EFC9A /* ErrorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8462832629B90BB9004EFC9A /* ErrorPresenter.swift */; };
 		8484C2E929B132D20018596C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484C2E829B132D20018596C /* AppDelegate.swift */; };
 		8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484C2EA29B132D20018596C /* SceneDelegate.swift */; };
 		8484C2F229B132D30018596C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8484C2F129B132D30018596C /* Assets.xcassets */; };
@@ -17,7 +16,6 @@
 
 /* Begin PBXFileReference section */
 		8462832329B8C6A7004EFC9A /* TurboNavigator */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = TurboNavigator; path = ..; sourceTree = "<group>"; };
-		8462832629B90BB9004EFC9A /* ErrorPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorPresenter.swift; sourceTree = "<group>"; };
 		8484C2E529B132D20018596C /* Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Demo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8484C2E829B132D20018596C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8484C2EA29B132D20018596C /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -61,7 +59,6 @@
 			children = (
 				8484C2F629B132D30018596C /* Info.plist */,
 				8484C2E829B132D20018596C /* AppDelegate.swift */,
-				8462832629B90BB9004EFC9A /* ErrorPresenter.swift */,
 				8484C2EA29B132D20018596C /* SceneDelegate.swift */,
 				8484C2F129B132D30018596C /* Assets.xcassets */,
 				8484C2F329B132D30018596C /* LaunchScreen.storyboard */,
@@ -161,7 +158,6 @@
 			files = (
 				8484C2E929B132D20018596C /* AppDelegate.swift in Sources */,
 				8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */,
-				8462832729B90BB9004EFC9A /* ErrorPresenter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     private let baseURL = URL(string: "http://localhost:3000")!
     private lazy var turboNavigator = TurboNavigator(delegate: self, pathConfiguration: pathConfiguration)
     private lazy var pathConfiguration = PathConfiguration(sources: [
-        .server(baseURL.appending(path: "/configuration"))
+        .server(baseURL.appendingPathComponent("/configuration"))
     ])
 
     private func createWindow(in windowScene: UIWindowScene) {

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -33,12 +33,4 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 }
 
-extension SceneDelegate: TurboNavigationDelegate {
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
-        if let errorPresenter = visitable as? ErrorPresenter {
-            errorPresenter.presentError(error) {
-                session.reload()
-            }
-        }
-    }
-}
+extension SceneDelegate: TurboNavigationDelegate {}

--- a/README.md
+++ b/README.md
@@ -255,3 +255,23 @@ class MyCustomClass: TurboNavigationDelegate {
     }
 }
 ```
+
+### Customized error handling
+
+By default, Turbo Navigator will automatically handle any errors that occur when performing visits. The error's localized description and a button to retry the request is displayed.
+
+You can customize the error handling by overriding the following delegate method.
+
+```swift
+extension MyCustomClass: TurboNavigationDelegate {
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
+        if case let TurboError.http(statusCode) = error, statusCode == 401 {
+            // Custom error handling for 401 responses.
+        } else if let errorPresenter = visitable as? ErrorPresenter {
+            errorPresenter.presentError(error) {
+                retry()
+            }
+        }
+    }
+}
+```

--- a/Sources/ErrorPresenter.swift
+++ b/Sources/ErrorPresenter.swift
@@ -1,13 +1,13 @@
 import SwiftUI
 import UIKit
 
-protocol ErrorPresenter: UIViewController {
+public protocol ErrorPresenter: UIViewController {
     typealias Handler = () -> Void
 
     func presentError(_ error: Error, handler: @escaping Handler)
 }
 
-extension ErrorPresenter {
+public extension ErrorPresenter {
     func presentError(_ error: Error, handler: @escaping () -> Void) {
         let errorView = ErrorView(error: error) { [unowned self] in
             handler()

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -17,7 +17,7 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
     /// If not implemented, will present the error's localized description and a Retry button.
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, reload: @escaping RetryBlock)
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock)
 
     /// Optional. Implement to customize handling of external URLs.
     /// If not implemented, will present `SFSafariViewController` as a modal and load the URL.
@@ -33,10 +33,10 @@ public extension TurboNavigationDelegate {
         VisitableViewController(url: proposal.url)
     }
 
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, reload: @escaping RetryBlock) {
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
         if let errorPresenter = visitable as? ErrorPresenter {
             errorPresenter.presentError(error) {
-                reload()
+                retry()
             }
         }
     }

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -5,9 +5,7 @@ import WebKit
 /// Implement to be notified when certain navigations are performed
 /// or to render a native controller instead of a Turbo web visit.
 public protocol TurboNavigationDelegate: AnyObject {
-    /// An error occurred loading the request, present it to the user.
-    /// Retry the request by calling `session.reload()`.
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error)
+    typealias RetryBlock = () -> Void
 
     /// Respond to authentication challenge presented by web servers behing basic auth.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
@@ -15,6 +13,11 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Optional. Implement to override or customize the controller to be displayed.
     /// Return `nil` to not display or route anything.
     func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController?
+
+    /// Optional. An error occurred loading the request, present it to the user.
+    /// Retry the request by executing the closure.
+    /// If not implemented, will present the error's localized description and a Retry button.
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, reload: @escaping RetryBlock)
 
     /// Optional. Implement to customize handling of external URLs.
     /// If not implemented, will present `SFSafariViewController` as a modal and load the URL.
@@ -28,6 +31,14 @@ public protocol TurboNavigationDelegate: AnyObject {
 public extension TurboNavigationDelegate {
     func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
         VisitableViewController(url: proposal.url)
+    }
+
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, reload: @escaping RetryBlock) {
+        if let errorPresenter = visitable as? ErrorPresenter {
+            errorPresenter.presentError(error) {
+                reload()
+            }
+        }
     }
 
     func openExternalURL(_ url: URL, from controller: UIViewController) {

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -215,7 +215,9 @@ extension TurboNavigator: SessionDelegate {
     }
 
     public func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {
-        delegate.session(session, didFailRequestForVisitable: visitable, error: error)
+        delegate.visitableDidFailRequest(visitable, error: error) {
+            session.reload()
+        }
     }
 
     public func sessionWebViewProcessDidTerminate(_ session: Session) {


### PR DESCRIPTION
Automatically handle errors with a SwiftUI view. The error's localized description is shown with a button to reload the request.

<img width="437" alt="image" src="https://github.com/joemasilotti/TurboNavigator/assets/2092156/0692d011-31b9-47e1-a429-5ca50042f00e">

Developers can override the delegate to customize the error handling.

Closes #20.