### PR TITLE
Allow a preconfigured session to be handled by someone other than TurboNavigator

### DIFF
--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -4,33 +4,19 @@ import UIKit
 import WebKit
 
 /// Handles navigation to new URLs using the following rules:
-/// https://masilotti.notion.site/Turbo-Native-iOS-navigation-4fd3dc638c3e4d2cab7ec5582656cbbb
+/// https://github.com/joemasilotti/TurboNavigator
 public class TurboNavigator {
-    
-    /// Allows the caller to provide a `Turbo.Session` that already has a path configuration and a delegate.
-    ///
+    /// Default initializer.
     /// - Parameters:
-    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
-    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
-    ///   - mainNavController: main navigation stack
-    ///   - modalNavController: modal navigation stack
-    ///   - delegate: notified as needed
-    public init(preconfiguredMainSession: Turbo.Session,
-                preconfiguredModalSession: Turbo.Session,
-                mainNavController: UINavigationController = UINavigationController(),
-                modalNavController: UINavigationController = UINavigationController(),
-                delegate: TurboNavigationDelegate) {
-        
-        self.session = preconfiguredMainSession
-        self.navigationController = mainNavController
-        
-        self.modalSession = preconfiguredModalSession
-        self.modalNavigationController = modalNavController
-        
-        self.delegate = delegate
-    }
-    
-    public init(delegate: TurboNavigationDelegate, pathConfiguration: PathConfiguration? = nil, navigationController: UINavigationController = UINavigationController(), modalNavigationController: UINavigationController = UINavigationController()) {
+    ///   - delegate: handle custom controller routing
+    ///   - pathConfiguration: assigned to internal `Session` instances for custom configuration
+    ///   - navigationController: optional: override the main navigation stack
+    ///   - modalNavigationController: optional: override the modal navigation stack
+    public init(delegate: TurboNavigationDelegate,
+                pathConfiguration: PathConfiguration? = nil,
+                navigationController: UINavigationController = UINavigationController(),
+                modalNavigationController: UINavigationController = UINavigationController())
+    {
         self.session = Session(webView: TurboConfig.shared.makeWebView())
         self.modalSession = Session(webView: TurboConfig.shared.makeWebView())
         self.delegate = delegate
@@ -41,6 +27,28 @@ public class TurboNavigator {
         modalSession.delegate = self
         session.pathConfiguration = pathConfiguration
         modalSession.pathConfiguration = pathConfiguration
+    }
+
+    /// Provide `Turbo.Session` instances with preconfigured path configurations and delegates.
+    /// Note that TurboNavigationDelegate.controller(_:forProposal:) will no longer be called.
+    /// - Parameters:
+    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
+    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
+    ///   - delegate: handle non-routing behavior, like custom error handling
+    ///   - navigationController: optional: override the main navigation stack
+    ///   - modalNavigationController: optional: override the modal navigation stack
+    public init(preconfiguredMainSession: Turbo.Session,
+                preconfiguredModalSession: Turbo.Session,
+                delegate: TurboNavigationDelegate,
+                navigationController: UINavigationController = UINavigationController(),
+                modalNavigationController: UINavigationController = UINavigationController())
+    {
+        self.session = preconfiguredMainSession
+        self.modalSession = preconfiguredModalSession
+        self.navigationController = navigationController
+        self.modalNavigationController = modalNavigationController
+
+        self.delegate = delegate
     }
 
     public var rootViewController: UIViewController { navigationController }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -6,6 +6,30 @@ import WebKit
 /// Handles navigation to new URLs using the following rules:
 /// https://masilotti.notion.site/Turbo-Native-iOS-navigation-4fd3dc638c3e4d2cab7ec5582656cbbb
 public class TurboNavigator {
+    
+    /// Allows the caller to provide a `Turbo.Session` that already has a path configuration and a delegate.
+    ///
+    /// - Parameters:
+    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
+    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
+    ///   - mainNavController: main navigation stack
+    ///   - modalNavController: modal navigation stack
+    ///   - delegate: notified as needed
+    public init(preconfiguredMainSession: Turbo.Session,
+                preconfiguredModalSession: Turbo.Session,
+                mainNavController: UINavigationController = UINavigationController(),
+                modalNavController: UINavigationController = UINavigationController(),
+                delegate: TurboNavigationDelegate) {
+        
+        self.session = preconfiguredMainSession
+        self.navigationController = mainNavController
+        
+        self.modalSession = preconfiguredModalSession
+        self.modalNavigationController = modalNavController
+        
+        self.delegate = delegate
+    }
+    
     public init(delegate: TurboNavigationDelegate, pathConfiguration: PathConfiguration? = nil, navigationController: UINavigationController = UINavigationController(), modalNavigationController: UINavigationController = UINavigationController()) {
         self.session = Session(webView: TurboConfig.shared.makeWebView())
         self.modalSession = Session(webView: TurboConfig.shared.makeWebView())

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -4,7 +4,7 @@ import UIKit
 import WebKit
 
 /// Handles navigation to new URLs using the following rules:
-/// https://github.com/joemasilotti/TurboNavigator
+/// https://github.com/joemasilotti/TurboNavigator#handled-flows
 public class TurboNavigator {
     /// Default initializer.
     /// - Parameters:


### PR DESCRIPTION
`TurboNavigator` offers great defaults for a lot of `Turbo.Session` behavior. However, some behavior may want to be modified by the app. 

Some examples may be...
- Using a `Turbo.Session` with a subclass of `WKWebView`
- Customizing `Turbo.Session` delegate behavior

This PR adds an initializer that allows `TurboNavigator` to focus on the actual navigation, and reserves session delegation rights.