### PR TITLE
Fix typo in "replace" code examples

### DIFF
--- a/Demo/Server/app/views/modals/replace.html.erb
+++ b/Demo/Server/app/views/modals/replace.html.erb
@@ -3,4 +3,4 @@
 <p class="my-3">This screen replaced the previous modal one.</p>
 
 <p class="mb-0">Trigger this by adding the following to a link already configured to be presented modaly:</p>
-<p><code>data: {turbo_action :replace}</code></p>
+<p><code>data: {turbo_action: :replace}</code></p>

--- a/Demo/Server/app/views/navigations/replace.html.erb
+++ b/Demo/Server/app/views/navigations/replace.html.erb
@@ -3,4 +3,4 @@
 <p class="my-3">This screen replaced the previous one.</p>
 
 <p class="mb-0">Trigger this by adding the following to a link:</p>
-<p><code>data: {turbo_action :replace}</code></p>
+<p><code>data: {turbo_action: :replace}</code></p>


### PR DESCRIPTION
Noticed this small typo in the code examples for `/modal/replace` and `/navigation/replace` pages in the Demo app while getting `replace` working in my app