### PR TITLE
Turbo navigating coordinator

### DIFF
--- a/Sources/PathConfigIdentifiable.swift
+++ b/Sources/PathConfigIdentifiable.swift
@@ -1,0 +1,13 @@
+//
+//  PathConfigIdentifiable.swift
+//  Calendar
+//
+//  Created by Fernando Olivares on 11/09/23.
+//
+
+import UIKit
+
+/// A covenient way to identify view controllers.
+public protocol PathConfigViewControllerIdentifiable : UIViewController {
+    static var viewControllerPathConfigIdentifier: String { get }
+}

--- a/Sources/TurboNavigatingCoordinator.swift
+++ b/Sources/TurboNavigatingCoordinator.swift
@@ -4,11 +4,36 @@ import SafariServices
 
 public class TurboNavigatingCoordinator : TurboNavigationDelegate {
     
+    public private(set) var navigators: [TurboNavigator]
+    
+    public var rootNavigator: TurboNavigator { navigators.first! }
+    
+    weak var delegate: TurboNavigatingCoordinatorDelegate?
+    
+    public init() {
+        navigators = []
+        navigators.append(TurboNavigator(delegate: self))
+    }
 }
 
 public extension TurboNavigatingCoordinator {
     
-    func handle(proposal: VisitProposal) -> ProposalResult { .accept }
+    func handle(proposal: VisitProposal, navigator: TurboNavigator) -> ProposalResult {
+        
+        guard let delegate else { return .accept }
+        
+        switch delegate.reroute(proposal: proposal,
+                                from: navigator,
+                                coordinator: self) {
+            
+        case .follow(let result):
+            return result
+            
+        case .reroute(let newNavigator):
+            newNavigator.route(proposal)
+            return .reject
+        }
+    }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
         if let errorPresenter = visitable as? ErrorPresenter {

--- a/Sources/TurboNavigatingCoordinator.swift
+++ b/Sources/TurboNavigatingCoordinator.swift
@@ -41,7 +41,7 @@ public extension TurboNavigatingCoordinator {
                                 from: navigator,
                                 coordinator: self) {
             
-        case .follow(let result):
+        case .continue(let result):
             return result
             
         case .reroute(let newNavigator):

--- a/Sources/TurboNavigatingCoordinator.swift
+++ b/Sources/TurboNavigatingCoordinator.swift
@@ -1,0 +1,35 @@
+import UIKit
+import Turbo
+import SafariServices
+
+public class TurboNavigatingCoordinator : TurboNavigationDelegate {
+    
+}
+
+public extension TurboNavigatingCoordinator {
+    
+    func handle(proposal: VisitProposal) -> ProposalResult { .accept }
+
+    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
+        if let errorPresenter = visitable as? ErrorPresenter {
+            errorPresenter.presentError(error) {
+                retry()
+            }
+        }
+    }
+
+    func openExternalURL(_ url: URL, from controller: UIViewController) {
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            safariViewController.preferredControlTintColor = .tintColor
+        }
+        controller.present(safariViewController, animated: true)
+    }
+
+    func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+
+    func sessionDidLoadWebView(_ session: Session) {}
+}

--- a/Sources/TurboNavigatingCoordinator.swift
+++ b/Sources/TurboNavigatingCoordinator.swift
@@ -2,20 +2,35 @@ import UIKit
 import Turbo
 import SafariServices
 
+/// Allows communication between different `TurboNavigator`s.
 public class TurboNavigatingCoordinator : TurboNavigationDelegate {
     
     public private(set) var navigators: [TurboNavigator]
     
+    /// Convenience: Returns the first navigator.
     public var rootNavigator: TurboNavigator { navigators.first! }
     
-    weak var delegate: TurboNavigatingCoordinatorDelegate?
+    public weak var delegate: TurboNavigatingCoordinatorDelegate?
     
-    public init() {
+    /// After initialization, `navigators` will always have at least 1 `TurboNavigator`.
+    ///
+    /// - Parameter rootNavigator: the first navigator, if given
+    public init(rootNavigator: TurboNavigator? = nil) {
         navigators = []
-        navigators.append(TurboNavigator(delegate: self))
+        
+        if let rootNavigator {
+            navigators.append(rootNavigator)
+        } else {
+            navigators.append(TurboNavigator(delegate: self))
+        }
+    }
+    
+    public func replaceRootNavigator(with newRootNavigator: TurboNavigator) {
+        navigators[0] = newRootNavigator
     }
 }
 
+// MARK: TurboNavigationDelegate
 public extension TurboNavigatingCoordinator {
     
     func handle(proposal: VisitProposal, navigator: TurboNavigator) -> ProposalResult {

--- a/Sources/TurboNavigatingCoordinatorDelegate.swift
+++ b/Sources/TurboNavigatingCoordinatorDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Turbo
 
-protocol TurboNavigatingCoordinatorDelegate : AnyObject {
+public protocol TurboNavigatingCoordinatorDelegate : AnyObject {
     
     /// Allows a requested `VisitProposal` to be routed to another `TurboNavigator`.
     ///
@@ -16,7 +16,7 @@ protocol TurboNavigatingCoordinatorDelegate : AnyObject {
 }
 
 /// Return from `reroute(proposal:from:coordinator:)` to reroute `VisitProposal`, if needed.
-enum VisitProposalRoute {
+public enum VisitProposalRoute {
     case follow(ProposalResult)
     case reroute(TurboNavigator)
 }

--- a/Sources/TurboNavigatingCoordinatorDelegate.swift
+++ b/Sources/TurboNavigatingCoordinatorDelegate.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Turbo
+
+protocol TurboNavigatingCoordinatorDelegate : AnyObject {
+    
+    /// Allows a requested `VisitProposal` to be routed to another `TurboNavigator`.
+    ///
+    /// - Parameters:
+    ///   - proposal: the proposal to be rerouted
+    ///   - navigator: the navigator that is proposing the visit
+    ///   - coordinator: the coordinator handling all navigators
+    /// - Returns: whether the proposal is followed by `navigator` or routed elsewhere
+    func reroute(proposal: VisitProposal,
+                 from navigator: TurboNavigator,
+                 coordinator: TurboNavigatingCoordinator) -> VisitProposalRoute
+}
+
+/// Return from `reroute(proposal:from:coordinator:)` to reroute `VisitProposal`, if needed.
+enum VisitProposalRoute {
+    case follow(ProposalResult)
+    case reroute(TurboNavigator)
+}

--- a/Sources/TurboNavigatingCoordinatorDelegate.swift
+++ b/Sources/TurboNavigatingCoordinatorDelegate.swift
@@ -17,6 +17,6 @@ public protocol TurboNavigatingCoordinatorDelegate : AnyObject {
 
 /// Return from `reroute(proposal:from:coordinator:)` to reroute `VisitProposal`, if needed.
 public enum VisitProposalRoute {
-    case follow(ProposalResult)
+    case `continue`(ProposalResult)
     case reroute(TurboNavigator)
 }

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -10,9 +10,14 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Respond to authentication challenge presented by web servers behing basic auth.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
-    /// Optional. Implement to override or customize the controller to be displayed.
-    /// Return `nil` to not display or route anything.
-    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController?
+    /// Optional. Allow or cancel a visit.
+    /// If allowed, you may provide a view controller to be displayed, otherwise a new `VisitableViewController` is used.
+    /// If rejected, no changes to navigation occur.
+    /// If not implemented, proposals are accepted and a new `VisitableViewController` is displayed.
+    ///
+    /// - Parameter proposal: navigation destination
+    /// - Returns: how to react to the visit proposal
+    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse
 
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
@@ -29,9 +34,8 @@ public protocol TurboNavigationDelegate: AnyObject {
 }
 
 public extension TurboNavigationDelegate {
-    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
-        VisitableViewController(url: proposal.url)
-    }
+    
+    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse { .acceptWithVisitableViewController }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
         if let errorPresenter = visitable as? ErrorPresenter {
@@ -55,4 +59,10 @@ public extension TurboNavigationDelegate {
     }
 
     func sessionDidLoadWebView(_ session: Session) {}
+}
+
+public enum VisitProposalResponse : Equatable {
+    case acceptWithVisitableViewController
+    case acceptWithCustom(UIViewController)
+    case reject
 }

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -17,7 +17,7 @@ public protocol TurboNavigationDelegate: AnyObject {
     ///
     /// - Parameter proposal: navigation destination
     /// - Returns: how to react to the visit proposal
-    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse
+    func response(forProposal proposal: VisitProposal) -> ProposalResult
 
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
@@ -35,7 +35,7 @@ public protocol TurboNavigationDelegate: AnyObject {
 
 public extension TurboNavigationDelegate {
     
-    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse { .acceptWithVisitableViewController }
+    func response(forProposal proposal: VisitProposal) -> ProposalResult { .accept }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
         if let errorPresenter = visitable as? ErrorPresenter {
@@ -61,8 +61,14 @@ public extension TurboNavigationDelegate {
     func sessionDidLoadWebView(_ session: Session) {}
 }
 
-public enum VisitProposalResponse : Equatable {
-    case acceptWithVisitableViewController
-    case acceptWithCustom(UIViewController)
+/// Return from `handle(proposal:)` to route a custom controller.
+public enum ProposalResult : Equatable {
+    /// Route a `VisitableViewController`.
+    case accept
+    
+    /// Route a custom `UIViewController` or subclass
+    case acceptCustom(UIViewController)
+
+    /// Do not route. Navigation is not modified.
     case reject
 }

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -16,8 +16,9 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// If not implemented, proposals are accepted and a new `VisitableViewController` is displayed.
     ///
     /// - Parameter proposal: navigation destination
+    /// - Parameter navigator: the navigator proposing the visit
     /// - Returns: how to react to the visit proposal
-    func handle(proposal: VisitProposal) -> ProposalResult
+    func handle(proposal: VisitProposal, navigator: TurboNavigator) -> ProposalResult
 
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -33,34 +33,6 @@ public protocol TurboNavigationDelegate: AnyObject {
     func sessionDidLoadWebView(_ session: Session)
 }
 
-public extension TurboNavigationDelegate {
-    
-    func handle(proposal: VisitProposal) -> ProposalResult { .accept }
-
-    func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
-        if let errorPresenter = visitable as? ErrorPresenter {
-            errorPresenter.presentError(error) {
-                retry()
-            }
-        }
-    }
-
-    func openExternalURL(_ url: URL, from controller: UIViewController) {
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        if #available(iOS 15.0, *) {
-            safariViewController.preferredControlTintColor = .tintColor
-        }
-        controller.present(safariViewController, animated: true)
-    }
-
-    func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-        completionHandler(.performDefaultHandling, nil)
-    }
-
-    func sessionDidLoadWebView(_ session: Session) {}
-}
-
 /// Return from `handle(proposal:)` to route a custom controller.
 public enum ProposalResult : Equatable {
     /// Route a `VisitableViewController`.

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -10,14 +10,14 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Respond to authentication challenge presented by web servers behing basic auth.
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
-    /// Optional. Allow or cancel a visit.
-    /// If allowed, you may provide a view controller to be displayed, otherwise a new `VisitableViewController` is used.
+    /// Optional. Accept or reject a visit proposal.
+    /// If accepted, you may provide a view controller to be displayed, otherwise a new `VisitableViewController` is displayed.
     /// If rejected, no changes to navigation occur.
     /// If not implemented, proposals are accepted and a new `VisitableViewController` is displayed.
     ///
     /// - Parameter proposal: navigation destination
     /// - Returns: how to react to the visit proposal
-    func response(forProposal proposal: VisitProposal) -> ProposalResult
+    func handle(proposal: VisitProposal) -> ProposalResult
 
     /// Optional. An error occurred loading the request, present it to the user.
     /// Retry the request by executing the closure.
@@ -35,7 +35,7 @@ public protocol TurboNavigationDelegate: AnyObject {
 
 public extension TurboNavigationDelegate {
     
-    func response(forProposal proposal: VisitProposal) -> ProposalResult { .accept }
+    func handle(proposal: VisitProposal) -> ProposalResult { .accept }
 
     func visitableDidFailRequest(_ visitable: Visitable, error: Error, retry: @escaping RetryBlock) {
         if let errorPresenter = visitable as? ErrorPresenter {

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -70,7 +70,7 @@ public class TurboNavigator {
     private unowned let delegate: TurboNavigationDelegate
 
     private func controller(for proposal: VisitProposal) -> UIViewController? {
-        switch delegate.response(forProposal: proposal) {
+        switch delegate.handle(proposal: proposal) {
             
         case .accept:
             return VisitableViewController(url: proposal.url)

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -72,10 +72,10 @@ public class TurboNavigator {
     private func controller(for proposal: VisitProposal) -> UIViewController? {
         switch delegate.response(forProposal: proposal) {
             
-        case .acceptWithVisitableViewController:
+        case .accept:
             return VisitableViewController(url: proposal.url)
             
-        case .acceptWithCustom(let customViewController):
+        case .acceptCustom(let customViewController):
             return customViewController
             
         case .reject:

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -4,33 +4,19 @@ import UIKit
 import WebKit
 
 /// Handles navigation to new URLs using the following rules:
-/// https://masilotti.notion.site/Turbo-Native-iOS-navigation-4fd3dc638c3e4d2cab7ec5582656cbbb
+/// https://github.com/joemasilotti/TurboNavigator
 public class TurboNavigator {
-    
-    /// Allows the caller to provide a `Turbo.Session` that already has a path configuration and a delegate.
-    ///
+    /// Default initializer.
     /// - Parameters:
-    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
-    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
-    ///   - mainNavController: main navigation stack
-    ///   - modalNavController: modal navigation stack
-    ///   - delegate: notified as needed
-    public init(preconfiguredMainSession: Turbo.Session,
-                preconfiguredModalSession: Turbo.Session,
-                mainNavController: UINavigationController = UINavigationController(),
-                modalNavController: UINavigationController = UINavigationController(),
-                delegate: TurboNavigationDelegate) {
-        
-        self.session = preconfiguredMainSession
-        self.navigationController = mainNavController
-        
-        self.modalSession = preconfiguredModalSession
-        self.modalNavigationController = modalNavController
-        
-        self.delegate = delegate
-    }
-    
-    public init(delegate: TurboNavigationDelegate, pathConfiguration: PathConfiguration? = nil, navigationController: UINavigationController = UINavigationController(), modalNavigationController: UINavigationController = UINavigationController()) {
+    ///   - delegate: handle custom controller routing
+    ///   - pathConfiguration: assigned to internal `Session` instances for custom configuration
+    ///   - navigationController: optional: override the main navigation stack
+    ///   - modalNavigationController: optional: override the modal navigation stack
+    public init(delegate: TurboNavigationDelegate,
+                pathConfiguration: PathConfiguration? = nil,
+                navigationController: UINavigationController = UINavigationController(),
+                modalNavigationController: UINavigationController = UINavigationController())
+    {
         self.session = Session(webView: TurboConfig.shared.makeWebView())
         self.modalSession = Session(webView: TurboConfig.shared.makeWebView())
         self.delegate = delegate
@@ -41,6 +27,28 @@ public class TurboNavigator {
         modalSession.delegate = self
         session.pathConfiguration = pathConfiguration
         modalSession.pathConfiguration = pathConfiguration
+    }
+
+    /// Provide `Turbo.Session` instances with preconfigured path configurations and delegates.
+    /// Note that TurboNavigationDelegate.controller(_:forProposal:) will no longer be called.
+    /// - Parameters:
+    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
+    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
+    ///   - delegate: handle non-routing behavior, like custom error handling
+    ///   - navigationController: optional: override the main navigation stack
+    ///   - modalNavigationController: optional: override the modal navigation stack
+    public init(preconfiguredMainSession: Turbo.Session,
+                preconfiguredModalSession: Turbo.Session,
+                delegate: TurboNavigationDelegate,
+                navigationController: UINavigationController = UINavigationController(),
+                modalNavigationController: UINavigationController = UINavigationController())
+    {
+        self.session = preconfiguredMainSession
+        self.modalSession = preconfiguredModalSession
+        self.navigationController = navigationController
+        self.modalNavigationController = modalNavigationController
+
+        self.delegate = delegate
     }
 
     public var rootViewController: UIViewController { navigationController }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -102,7 +102,7 @@ public class TurboNavigator {
     private unowned let delegate: TurboNavigationDelegate
 
     private func controller(for proposal: VisitProposal) -> UIViewController? {
-        switch delegate.handle(proposal: proposal) {
+        switch delegate.handle(proposal: proposal, navigator: self) {
             
         case .accept:
             return VisitableViewController(url: proposal.url)

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -6,6 +6,30 @@ import WebKit
 /// Handles navigation to new URLs using the following rules:
 /// https://masilotti.notion.site/Turbo-Native-iOS-navigation-4fd3dc638c3e4d2cab7ec5582656cbbb
 public class TurboNavigator {
+    
+    /// Allows the caller to provide a `Turbo.Session` that already has a path configuration and a delegate.
+    ///
+    /// - Parameters:
+    ///   - preconfiguredMainSession: a session whose delegate is not `TurboNavigator`
+    ///   - preconfiguredModalSession: a session whose delegate is not `TurboNavigator`
+    ///   - mainNavController: main navigation stack
+    ///   - modalNavController: modal navigation stack
+    ///   - delegate: notified as needed
+    public init(preconfiguredMainSession: Turbo.Session,
+                preconfiguredModalSession: Turbo.Session,
+                mainNavController: UINavigationController = UINavigationController(),
+                modalNavController: UINavigationController = UINavigationController(),
+                delegate: TurboNavigationDelegate) {
+        
+        self.session = preconfiguredMainSession
+        self.navigationController = mainNavController
+        
+        self.modalSession = preconfiguredModalSession
+        self.modalNavigationController = modalNavController
+        
+        self.delegate = delegate
+    }
+    
     public init(delegate: TurboNavigationDelegate, pathConfiguration: PathConfiguration? = nil, navigationController: UINavigationController = UINavigationController(), modalNavigationController: UINavigationController = UINavigationController()) {
         self.session = Session(webView: TurboConfig.shared.makeWebView())
         self.modalSession = Session(webView: TurboConfig.shared.makeWebView())

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -70,8 +70,17 @@ public class TurboNavigator {
     private unowned let delegate: TurboNavigationDelegate
 
     private func controller(for proposal: VisitProposal) -> UIViewController? {
-        let defaultController = VisitableViewController(url: proposal.url)
-        return delegate.controller(defaultController, forProposal: proposal)
+        switch delegate.response(forProposal: proposal) {
+            
+        case .acceptWithVisitableViewController:
+            return VisitableViewController(url: proposal.url)
+            
+        case .acceptWithCustom(let customViewController):
+            return customViewController
+            
+        case .reject:
+            return nil
+        }
     }
 
     private func presentAlert(_ alert: UIAlertController) {

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -4,7 +4,7 @@ import UIKit
 import WebKit
 
 /// Handles navigation to new URLs using the following rules:
-/// https://github.com/joemasilotti/TurboNavigator
+/// https://github.com/joemasilotti/TurboNavigator#handled-flows
 public class TurboNavigator {
     /// Default initializer.
     /// - Parameters:

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -15,4 +15,12 @@ public extension VisitProposal {
         }
         return .default
     }
+    
+    var viewController: String {
+        if let viewController = properties["view-controller"] as? String {
+            return viewController
+        }
+        
+        return "VisitableViewController"
+    }
 }

--- a/Tests/TurboNavigatingCoordinatorTests.swift
+++ b/Tests/TurboNavigatingCoordinatorTests.swift
@@ -3,20 +3,20 @@ import Turbo
 @testable import TurboNavigator
 import XCTest
 
-final class TurboNavigationDelegateTests: XCTestCase {
+final class TurboNavigatingCoordinatorTests: XCTestCase {
+    
     func test_controllerForProposal_defaultsToVisitableViewController() throws {
         let url = URL(string: "https://example.com")!
-
-        let response = delegate.handle(proposal: VisitProposal(url: url))
-
-        XCTAssertEqual(response, .accept)
+        coordinator.rootNavigator.route(url)
+        XCTAssert(coordinator.rootNavigator.navigationController.viewControllers.count == 1)
+        XCTAssertNotNil(coordinator.rootNavigator.navigationController.viewControllers.first as? VisitableViewController)
     }
 
     func test_openExternalURL_presentsSafariViewController() throws {
         let url = URL(string: "https://example.com")!
         let controller = TestableNavigationController()
 
-        delegate.openExternalURL(url, from: controller)
+        coordinator.openExternalURL(url, from: controller)
 
         XCTAssert(controller.presentedViewController is SFSafariViewController)
         XCTAssertEqual(controller.modalPresentationStyle, .pageSheet)
@@ -24,13 +24,7 @@ final class TurboNavigationDelegateTests: XCTestCase {
 
     // MARK: Private
 
-    private let delegate = DefaultDelegate()
-}
-
-// MARK: - DefaultDelegate
-
-private class DefaultDelegate: TurboNavigationDelegate {
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
+    private let coordinator = TurboNavigatingCoordinator()
 }
 
 // MARK: - VisitProposal extension

--- a/Tests/TurboNavigationDelegateTests.swift
+++ b/Tests/TurboNavigationDelegateTests.swift
@@ -7,10 +7,9 @@ final class TurboNavigationDelegateTests: XCTestCase {
     func test_controllerForProposal_defaultsToVisitableViewController() throws {
         let url = URL(string: "https://example.com")!
 
-        let controller = delegate.controller(VisitableViewController(), forProposal: VisitProposal(url: url))
+        let response = delegate.response(forProposal: VisitProposal(url: url))
 
-        let visitableViewController = try XCTUnwrap(controller as? VisitableViewController)
-        XCTAssertEqual(visitableViewController.visitableURL, url)
+        XCTAssertEqual(response, .acceptWithVisitableViewController)
     }
 
     func test_openExternalURL_presentsSafariViewController() throws {

--- a/Tests/TurboNavigationDelegateTests.swift
+++ b/Tests/TurboNavigationDelegateTests.swift
@@ -7,7 +7,7 @@ final class TurboNavigationDelegateTests: XCTestCase {
     func test_controllerForProposal_defaultsToVisitableViewController() throws {
         let url = URL(string: "https://example.com")!
 
-        let response = delegate.response(forProposal: VisitProposal(url: url))
+        let response = delegate.handle(proposal: VisitProposal(url: url))
 
         XCTAssertEqual(response, .accept)
     }

--- a/Tests/TurboNavigationDelegateTests.swift
+++ b/Tests/TurboNavigationDelegateTests.swift
@@ -9,7 +9,7 @@ final class TurboNavigationDelegateTests: XCTestCase {
 
         let response = delegate.response(forProposal: VisitProposal(url: url))
 
-        XCTAssertEqual(response, .acceptWithVisitableViewController)
+        XCTAssertEqual(response, .accept)
     }
 
     func test_openExternalURL_presentsSafariViewController() throws {

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -285,12 +285,12 @@ final class TurboNavigatorTests: XCTestCase {
 private class TestNavigationDelegate: TurboNavigationDelegate {
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
     
-    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse {
+    func response(forProposal proposal: VisitProposal) -> ProposalResult {
         if proposal.url.path == "/cancel" {
             return .reject
         }
         
-        return .acceptWithVisitableViewController
+        return .accept
     }
 }
 
@@ -312,12 +312,12 @@ private extension VisitProposal {
 
 private class AlertControllerDelegate: TurboNavigationDelegate {
     
-    func response(forProposal proposal: VisitProposal) -> VisitProposalResponse {
+    func response(forProposal proposal: VisitProposal) -> ProposalResult {
         if proposal.url.path == "/alert" {
-            return .acceptWithCustom(UIAlertController(title: "Alert", message: nil, preferredStyle: .alert))
+            return .acceptCustom(UIAlertController(title: "Alert", message: nil, preferredStyle: .alert))
         }
         
-        return .acceptWithVisitableViewController
+        return .accept
     }
 
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -252,7 +252,7 @@ final class TurboNavigatorTests: XCTestCase {
     }
 
     private var navigator: TurboNavigator!
-    private let delegate = EmptyDelegate()
+    private let delegate = TestNavigationDelegate()
     private var navigationController: TestableNavigationController!
     private var modalNavigationController: TestableNavigationController!
     private let window = UIWindow()
@@ -282,7 +282,7 @@ final class TurboNavigatorTests: XCTestCase {
 
 // MARK: - TurboNavigationDelegate
 
-private class EmptyDelegate: TurboNavigationDelegate {
+private class TestNavigationDelegate: TurboNavigationDelegate {
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
     
     func response(forProposal proposal: VisitProposal) -> VisitProposalResponse {

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -77,19 +77,6 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssert(navigationController.viewControllers.last is VisitableViewController)
         assertVisited(url: proposal.url, on: .main)
     }
-    
-    func test_default_default_default_visitProposalResponseCancelsNavigation() {
-        let topViewController = UIViewController()
-        navigationController.pushViewController(topViewController, animated: false)
-        XCTAssertEqual(navigationController.viewControllers.count, 2)
-
-        let proposal = VisitProposal(path: "/cancel")
-        navigator.route(proposal)
-
-        XCTAssertEqual(navigationController.viewControllers.count, 2)
-        XCTAssert(navigationController.topViewController == topViewController)
-        XCTAssertNotEqual(navigator.session.activeVisitable?.visitableURL, proposal.url)
-    }
 
     func test_default_modal_default_presentsModal() {
         let proposal = VisitProposal(context: .modal)
@@ -243,6 +230,19 @@ final class TurboNavigatorTests: XCTestCase {
         navigator.route(VisitProposal(path: "/alert"))
 
         XCTAssert(modalNavigationController.presentedViewController is UIAlertController)
+    }
+    
+    func test_none_visitProposalResponseCancelsNavigation() {
+        let topViewController = UIViewController()
+        navigationController.pushViewController(topViewController, animated: false)
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+
+        let proposal = VisitProposal(path: "/cancel")
+        navigator.route(proposal)
+
+        XCTAssertEqual(navigationController.viewControllers.count, 2)
+        XCTAssert(navigationController.topViewController == topViewController)
+        XCTAssertNotEqual(navigator.session.activeVisitable?.visitableURL, proposal.url)
     }
 
     // MARK: Private

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -283,9 +283,17 @@ final class TurboNavigatorTests: XCTestCase {
 // MARK: - TurboNavigationDelegate
 
 private class TestNavigationDelegate: TurboNavigationDelegate {
+    func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) { }
+    
+    func visitableDidFailRequest(_ visitable: Turbo.Visitable, error: Error, retry: @escaping RetryBlock) { }
+    
+    func openExternalURL(_ url: URL, from controller: UIViewController) { }
+    
+    func sessionDidLoadWebView(_ session: Turbo.Session) { }
+    
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
     
-    func handle(proposal: VisitProposal) -> ProposalResult {
+    func handle(proposal: VisitProposal, navigator: TurboNavigator) -> ProposalResult {
         if proposal.url.path == "/cancel" {
             return .reject
         }
@@ -311,8 +319,15 @@ private extension VisitProposal {
 // MARK: - AlertControllerDelegate
 
 private class AlertControllerDelegate: TurboNavigationDelegate {
+    func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) { }
     
-    func handle(proposal: VisitProposal) -> ProposalResult {
+    func visitableDidFailRequest(_ visitable: Turbo.Visitable, error: Error, retry: @escaping RetryBlock) {}
+    
+    func openExternalURL(_ url: URL, from controller: UIViewController) { }
+    
+    func sessionDidLoadWebView(_ session: Turbo.Session) { }
+
+    func handle(proposal: VisitProposal, navigator: TurboNavigator) -> ProposalResult {
         if proposal.url.path == "/alert" {
             return .acceptCustom(UIAlertController(title: "Alert", message: nil, preferredStyle: .alert))
         }
@@ -320,5 +335,5 @@ private class AlertControllerDelegate: TurboNavigationDelegate {
         return .accept
     }
 
-    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
+    func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) { }
 }

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -285,7 +285,7 @@ final class TurboNavigatorTests: XCTestCase {
 private class TestNavigationDelegate: TurboNavigationDelegate {
     func session(_ session: Session, didFailRequestForVisitable visitable: Visitable, error: Error) {}
     
-    func response(forProposal proposal: VisitProposal) -> ProposalResult {
+    func handle(proposal: VisitProposal) -> ProposalResult {
         if proposal.url.path == "/cancel" {
             return .reject
         }
@@ -312,7 +312,7 @@ private extension VisitProposal {
 
 private class AlertControllerDelegate: TurboNavigationDelegate {
     
-    func response(forProposal proposal: VisitProposal) -> ProposalResult {
+    func handle(proposal: VisitProposal) -> ProposalResult {
         if proposal.url.path == "/alert" {
             return .acceptCustom(UIAlertController(title: "Alert", message: nil, preferredStyle: .alert))
         }


### PR DESCRIPTION
This PR introduces another layer above `TurboNavigator` named `TurboNavigatingCoordinator`. This new layer will have a single responsibility: provide communication between `TurboNavigator`s. We've found this is necessary in several cases:

1. When a form is submitted, a `TurboNavigator` will clear its main session's snapshot cache. We've found it useful to clear other unrelated session's snapshots too.
2. Deciding which `TurboNavigator` is responsible for routing external URLs (e.g. a notification or a Universal Link).
3. Rerouting from one `TurboNavigator` to another.

Since this is a big change, this PR creates the new classes and addresses point 3. Once we all feel the implementation is right, I can move forward to adding points 1 and 2 in another PR.

Here's a small diagram as to how rerouting from one navigator to another may happen:

![New Drawing 12_concept](https://github.com/olivaresf/TurboNavigator/assets/253485/96b6c474-5937-4b2a-82f1-c478e341bcf4)

There's some changes from https://github.com/joemasilotti/TurboNavigator/pull/51, but those are temporary while we merge it. I'm also missing unit tests, but I wanted to get feedback early.

Missing:
- [ ] Unit testing for TurboNavigatingCoordinatorDelegate