### PR TITLE
View controller visit proposal extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ It shows off most of the navigation flows outlined above. There is also an examp
 
 You can also implement an optional method on the `TurboNavigationDelegate` to handle custom routing.
 
-This is useful to break out of the default behavior and/or render a native screen. You may inspect the provided proposal and decide routing based on any of its properties. For custom native screens, you may also include a "view-controller" property that will be passed along.
+This is useful to break out of the default behavior and/or render a native screen. You may inspect the provided proposal and decide routing based on any of its properties. For custom native screens, you may also include a `"view-controller"` property that will be passed along.
 
 ```json
 {
@@ -245,8 +245,7 @@ class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
 
     func handle(proposal: VisitProposal) -> ProposalResult {
-        if proposal.url.path == "/numbers" ||
-           proposal.viewController == "numbers" {
+        if proposal.viewController == "numbers" {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
         } else if proposal.presentation == .clearAll {
@@ -262,7 +261,7 @@ class MyCustomClass: TurboNavigationDelegate {
 }
 ```
 
-If you're relying on the "view-controller" property, we recommend your view controllers conform to `PathConfigurationIdentifiable`. You should also avoid using the class name as identifier, as that may change over time.
+If you're relying on the `"view-controller"` property, we recommend your view controllers conform to `PathConfigurationIdentifiable`. You should also avoid using the class name as identifier, as you might rename your controller in the future.
 
 ```swift
 class NumbersViewController: UIViewController, PathConfigurationIdentifiable {
@@ -273,8 +272,7 @@ class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
     
     func handle(proposal: VisitProposal) -> ProposalResult {
-        if proposal.url.path == "/numbers" ||
-           proposal.viewController == NumbersViewController.pathConfigurationIdentifier {
+        if proposal.viewController == NumbersViewController.pathConfigurationIdentifier {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
         } else ... 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
 
     func handle(proposal: VisitProposal) -> ProposalResult {
-        if proposal.url.path == "/numbers" || proposal.viewController == "numbers" {
+        if proposal.url.path == "/numbers" ||
+           proposal.viewController == "numbers" {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
         } else if proposal.presentation == .clearAll {
@@ -272,7 +273,8 @@ class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
     
     func handle(proposal: VisitProposal) -> ProposalResult {
-        if proposal.url.path == "/numbers" || proposal.viewController == NumbersViewController.pathConfigurationIdentifier {
+        if proposal.url.path == "/numbers" ||
+           proposal.viewController == NumbersViewController.pathConfigurationIdentifier {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
         } else ... 

--- a/README.md
+++ b/README.md
@@ -227,14 +227,25 @@ It shows off most of the navigation flows outlined above. There is also an examp
 
 You can also implement an optional method on the `TurboNavigationDelegate` to handle custom routing.
 
-This is useful to break out of the default behavior and/or render a native screen.
+This is useful to break out of the default behavior and/or render a native screen. You may inspect the provided proposal and decide routing based on any of its properties. For custom native screens, you may also include a "view-controller" property that will be passed along.
+
+```json
+{
+  "patterns": [
+    "/numbers$"
+  ],
+  "properties": {
+    "view-controller": "numbers"
+  }
+}
+```
 
 ```swift
 class MyCustomClass: TurboNavigationDelegate {
     let navigator = TurboNavigator(delegate: self)
 
-    func controller(_ controller: VisitableViewController, forProposal proposal: VisitProposal) -> UIViewController? {
-        if proposal.url.path == "/numbers" {
+    func handle(proposal: VisitProposal) -> ProposalResult {
+        if proposal.url.path == "/numbers" || proposal.viewController == "numbers" {
             // Let Turbo Navigator route this custom controller.
             return NumbersViewController()
         } else if proposal.presentation == .clearAll {
@@ -249,6 +260,27 @@ class MyCustomClass: TurboNavigationDelegate {
     }
 }
 ```
+
+If you're relying on the "view-controller" property, we recommend your view controllers conform to `PathConfigurationIdentifiable`.
+
+```swift
+class NumbersViewController: UIViewController, PathConfigurationIdentifiable {
+    static var pathConfigurationIdentifier: String { "numbers" }
+}
+
+class MyCustomClass: TurboNavigationDelegate {
+    let navigator = TurboNavigator(delegate: self)
+    
+    func handle(proposal: VisitProposal) -> ProposalResult {
+        if proposal.url.path == "/numbers" || proposal.viewController == NumbersViewController.pathConfigurationIdentifier {
+            // Let Turbo Navigator route this custom controller.
+            return NumbersViewController()
+        } else ... 
+            ...
+        }
+    }
+}
+``` 
 
 ## Custom configuration
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ class MyCustomClass: TurboNavigationDelegate {
 }
 ```
 
-If you're relying on the "view-controller" property, we recommend your view controllers conform to `PathConfigurationIdentifiable`.
+If you're relying on the "view-controller" property, we recommend your view controllers conform to `PathConfigurationIdentifiable`. You should also avoid using the class name as identifier, as that may change over time.
 
 ```swift
 class NumbersViewController: UIViewController, PathConfigurationIdentifiable {

--- a/Sources/PathConfigurationIdentifiable.swift
+++ b/Sources/PathConfigurationIdentifiable.swift
@@ -1,6 +1,21 @@
 import UIKit
 
-/// A covenient way to identify view controllers.
+/// As a convenience, your view controller may conform to `PathConfigurationIdentifiable`.
+/// You may then use the view controller's `pathConfigurationIdentifier` property instead of `proposal.url` when deciding how to handle a proposal. See `VisitProposal.viewController` on how to use this in your configuration file.
+///
+/// ```
+/// func handle(proposal: VisitProposal) -> ProposalResult {
+///    switch proposal.viewController {
+///
+///    case RecipeViewController.pathConfigurationIdentifier:
+///        return .accept(RecipeViewController.new)
+///
+///    default:
+///        return .accept
+///
+///    }
+///}
+/// ```
 public protocol PathConfigurationIdentifiable : UIViewController {
     static var pathConfigurationIdentifier: String { get }
 }

--- a/Sources/PathConfigurationIdentifiable.swift
+++ b/Sources/PathConfigurationIdentifiable.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+/// A covenient way to identify view controllers.
+public protocol PathConfigurationIdentifiable : UIViewController {
+    static var pathConfigurationIdentifier: String { get }
+}

--- a/Sources/PathConfigurationIdentifiable.swift
+++ b/Sources/PathConfigurationIdentifiable.swift
@@ -6,16 +6,13 @@ import UIKit
 /// ```
 /// func handle(proposal: VisitProposal) -> ProposalResult {
 ///    switch proposal.viewController {
-///
 ///    case RecipeViewController.pathConfigurationIdentifier:
 ///        return .accept(RecipeViewController.new)
-///
 ///    default:
 ///        return .accept
-///
 ///    }
-///}
+/// }
 /// ```
-public protocol PathConfigurationIdentifiable : UIViewController {
+public protocol PathConfigurationIdentifiable: UIViewController {
     static var pathConfigurationIdentifier: String { get }
 }

--- a/Sources/TurboIdentifiable.swift
+++ b/Sources/TurboIdentifiable.swift
@@ -1,6 +1,0 @@
-import UIKit
-
-/// A covenient way to identify view controllers.
-public protocol TurboIdentifiable : UIViewController {
-    static var viewControllerPathConfigIdentifier: String { get }
-}

--- a/Sources/TurboIdentifiable.swift
+++ b/Sources/TurboIdentifiable.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+/// A covenient way to identify view controllers.
+public protocol TurboIdentifiable : UIViewController {
+    static var viewControllerPathConfigIdentifier: String { get }
+}

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -15,7 +15,7 @@ public extension VisitProposal {
         }
         return .default
     }
-    
+
     /// Used to identify a custom native view controller if provided in the path configuration properties of a given pattern.
     ///
     /// For example, given the following configuration file:
@@ -27,11 +27,10 @@ public extension VisitProposal {
     ///       "patterns": [
     ///         "/recipes/*"
     ///       ],
-    ///
     ///       "properties": {
     ///         "view-controller": "recipes",
     ///       }
-    ///     },
+    ///     }
     ///  ]
     /// }
     /// ```
@@ -43,7 +42,7 @@ public extension VisitProposal {
         if let viewController = properties["view-controller"] as? String {
             return viewController
         }
-        
+
         return VisitableViewController.pathConfigurationIdentifier
     }
 }

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -15,4 +15,12 @@ public extension VisitProposal {
         }
         return .default
     }
+    
+    var viewController: String {
+        if let viewController = properties["view-controller"] as? String {
+            return viewController
+        }
+        
+        return "VisitableViewController"
+    }
 }

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -21,6 +21,6 @@ public extension VisitProposal {
             return viewController
         }
         
-        return "VisitableViewController"
+        return VisitableViewController.pathConfigurationIdentifier
     }
 }

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -16,6 +16,29 @@ public extension VisitProposal {
         return .default
     }
     
+    /// Used to identify a custom native view controller if provided in the path configuration properties of a given pattern.
+    ///
+    /// For example, given the following configuration file:
+    ///
+    /// ```
+    /// {
+    ///   "rules": [
+    ///     {
+    ///       "patterns": [
+    ///         "/recipes/*"
+    ///       ],
+    ///
+    ///       "properties": {
+    ///         "view-controller": "RecipeViewController",
+    ///       }
+    ///     },
+    ///  ]
+    /// }
+    /// ```
+    ///
+    /// A VisitProposal to `https://example.com/recipes/` will have `proposal.viewController == "RecipeViewController"`
+    /// 
+    /// A default value is provided in case the view controller property is missing from the configuration file.
     var viewController: String {
         if let viewController = properties["view-controller"] as? String {
             return viewController

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -29,16 +29,16 @@ public extension VisitProposal {
     ///       ],
     ///
     ///       "properties": {
-    ///         "view-controller": "RecipeViewController",
+    ///         "view-controller": "recipes",
     ///       }
     ///     },
     ///  ]
     /// }
     /// ```
     ///
-    /// A VisitProposal to `https://example.com/recipes/` will have `proposal.viewController == "RecipeViewController"`
-    /// 
-    /// A default value is provided in case the view controller property is missing from the configuration file.
+    /// A VisitProposal to `https://example.com/recipes/` will have `proposal.viewController == "recipes"`
+    ///
+    /// A default value is provided in case the view controller property is missing from the configuration file. This will route the default `VisitableViewController`.
     var viewController: String {
         if let viewController = properties["view-controller"] as? String {
             return viewController

--- a/Sources/VisitableViewControllerExtension.swift
+++ b/Sources/VisitableViewControllerExtension.swift
@@ -1,0 +1,5 @@
+import Turbo
+
+extension VisitableViewController : PathConfigurationIdentifiable {
+    public static var pathConfigurationIdentifier: String { "web" }
+}

--- a/Sources/VisitableViewControllerExtension.swift
+++ b/Sources/VisitableViewControllerExtension.swift
@@ -1,5 +1,5 @@
 import Turbo
 
-extension VisitableViewController : PathConfigurationIdentifiable {
+extension VisitableViewController: PathConfigurationIdentifiable {
     public static var pathConfigurationIdentifier: String { "web" }
 }


### PR DESCRIPTION
Briefly discussed here: https://github.com/joemasilotti/TurboNavigator/pull/53/files#r1329138612

The use case for this behavior is making sure that the "view-controller" property in the Path Config matches a native ViewController. So, for example if we have:

```json
{
  "rules": [
      {
        "patterns": [
          "/recipes/*"
        ],
        "properties": {
            "view-controller": "RecipeViewController",
        }
      },
  ]
}
```

A view controller may identify itself by implementing TurboIdentifiable:

```swift
 class RecipeViewController: UIViewController, TurboIdentifiable {
    
    static var viewControllerPathConfigIdentifier: String { "RecipeViewController" }
}
```

And so, a `TurboNavigator`'s `handleProposal(proposal:)`  delegate may work something like this:

```swift
func handle(proposal: VisitProposal) -> ProposalResult {
        
        switch proposal.viewController {
            
        case RecipeViewController.viewControllerPathConfigIdentifier:
            return .accept(RecipeViewController.new)
            
        default:
            return .accept

        }
    }
```

Naming isn't final. Open to any suggestions.
