### PR TITLE
Clean up demo project

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 			isa = PBXGroup;
 			children = (
 				8484C2E729B132D20018596C /* Demo */,
-				8484C2FE29B133880018596C /* Frameworks */,
 				8484C2FC29B132E90018596C /* Packages */,
 				8484C2E629B132D20018596C /* Products */,
 			);
@@ -72,13 +71,6 @@
 				8462832329B8C6A7004EFC9A /* TurboNavigator */,
 			);
 			name = Packages;
-			sourceTree = "<group>";
-		};
-		8484C2FE29B133880018596C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Demo/Demo/AppDelegate.swift
+++ b/Demo/Demo/AppDelegate.swift
@@ -1,10 +1,4 @@
 import UIKit
 
 @main
-class AppDelegate: UIResponder {}
-
-extension AppDelegate: UIApplicationDelegate {
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-}
+class AppDelegate: UIResponder, UIApplicationDelegate {}

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -1,35 +1,25 @@
 import Turbo
 import TurboNavigator
 import UIKit
-import WebKit
+
+let baseURL = URL(string: "http://localhost:3000")!
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
 
-    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard let windowScene = scene as? UIWindowScene
-        else { fatalError("Expected a UIWindowScene.") }
-
-        createWindow(in: windowScene)
-    }
-
-    // MARK: - Private
-
-    private let baseURL = URL(string: "http://localhost:3000")!
     private lazy var turboNavigator = TurboNavigator(delegate: self, pathConfiguration: pathConfiguration)
     private lazy var pathConfiguration = PathConfiguration(sources: [
         .server(baseURL.appendingPathComponent("/configuration"))
     ])
 
-    private func createWindow(in windowScene: UIWindowScene) {
-        let window = UIWindow(windowScene: windowScene)
-        window.backgroundColor = .white
-        self.window = window
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        guard let windowScene = scene as? UIWindowScene else { return }
 
-        window.makeKeyAndVisible()
-        window.rootViewController = turboNavigator.rootViewController
+        self.window = UIWindow(windowScene: windowScene)
+        self.window?.makeKeyAndVisible()
 
-        turboNavigator.route(baseURL)
+        self.window?.rootViewController = self.turboNavigator.rootViewController
+        self.turboNavigator.route(baseURL)
     }
 }
 


### PR DESCRIPTION
This PR removes even more of the default iOS boilerplate that isn't needed to get Turbo Navigator up and running.