### PR TITLE
Strada

### DIFF
--- a/Demo/Demo.xcodeproj/project.pbxproj
+++ b/Demo/Demo.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8484C2EA29B132D20018596C /* SceneDelegate.swift */; };
 		8484C2F229B132D30018596C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8484C2F129B132D30018596C /* Assets.xcassets */; };
 		8484C2F529B132D30018596C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8484C2F329B132D30018596C /* LaunchScreen.storyboard */; };
+		84A014382ACA23CE00393FD3 /* FormComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A014372ACA23CE00393FD3 /* FormComponent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -22,6 +23,7 @@
 		8484C2F129B132D30018596C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8484C2F429B132D30018596C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		8484C2F629B132D30018596C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		84A014372ACA23CE00393FD3 /* FormComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormComponent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				8484C2F629B132D30018596C /* Info.plist */,
 				8484C2E829B132D20018596C /* AppDelegate.swift */,
 				8484C2EA29B132D20018596C /* SceneDelegate.swift */,
+				84A014372ACA23CE00393FD3 /* FormComponent.swift */,
 				8484C2F129B132D30018596C /* Assets.xcassets */,
 				8484C2F329B132D30018596C /* LaunchScreen.storyboard */,
 			);
@@ -148,6 +151,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84A014382ACA23CE00393FD3 /* FormComponent.swift in Sources */,
 				8484C2E929B132D20018596C /* AppDelegate.swift in Sources */,
 				8484C2EB29B132D20018596C /* SceneDelegate.swift in Sources */,
 			);

--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "strada-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hotwired/strada-ios",
+      "state" : {
+        "branch" : "main",
+        "revision" : "d8c1bcf1d9511c03e7beed07c05d29f33f9b6cde"
+      }
+    },
+    {
       "identity" : "turbo-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/hotwired/turbo-ios",

--- a/Demo/Demo/FormComponent.swift
+++ b/Demo/Demo/FormComponent.swift
@@ -1,0 +1,32 @@
+import Strada
+import UIKit
+
+final class FormComponent: BridgeComponent {
+    override class var name: String { "form" }
+
+    override func onReceive(message: Message) {
+        if message.event == "connect" {
+            addSubmitButton(message: message)
+        }
+    }
+
+    private var viewController: UIViewController? {
+        delegate.destination as? UIViewController
+    }
+
+    private func addSubmitButton(message: Message) {
+        guard let data: MessageData = message.data(), let viewController else { return }
+
+        let action = UIAction(title: data.title) { _ in
+            self.reply(to: "connect")
+        }
+
+        viewController.navigationItem.rightBarButtonItem = UIBarButtonItem(primaryAction: action)
+    }
+}
+
+private extension FormComponent {
+    struct MessageData: Decodable {
+        let title: String
+    }
+}

--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -18,6 +18,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         self.window?.makeKeyAndVisible()
 
+        TurboConfig.shared.stradaComponentTypes = [FormComponent.self]
+
         self.window?.rootViewController = self.turboNavigator.rootViewController
         self.turboNavigator.route(baseURL)
     }

--- a/Demo/Server/app/javascript/controllers/bridge/form_controller.js
+++ b/Demo/Server/app/javascript/controllers/bridge/form_controller.js
@@ -1,0 +1,21 @@
+import { BridgeComponent } from "@hotwired/strada"
+import { BridgeElement } from "@hotwired/strada"
+
+export default class extends BridgeComponent {
+  static component = "form"
+  static targets = ["submit"]
+
+  connect() {
+    super.connect()
+    this.notifyBridgeOfConnect()
+  }
+
+  notifyBridgeOfConnect() {
+    const submitButton = new BridgeElement(this.submitTarget)
+    const title = submitButton.title
+
+    this.send("connect", { title }, () => {
+      this.submitTarget.click()
+    })
+  }
+}

--- a/Demo/Server/app/javascript/controllers/index.js
+++ b/Demo/Server/app/javascript/controllers/index.js
@@ -3,3 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+
+import Bridge__FormController from "./bridge/form_controller"
+application.register("bridge--form", Bridge__FormController)

--- a/Demo/Server/app/views/resources/_form.html.erb
+++ b/Demo/Server/app/views/resources/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: resource, class: "row g-3", data: {"turbo-action": (resource.persisted? ? "replace" : "advance")}) do |form| %>
+<%= form_with(model: resource, class: "row g-3", data: {"turbo-action": (resource.persisted? ? "replace" : "advance"), controller: "bridge--form"}) do |form| %>
   <% if resource.errors.any? %>
     <div class="alert alert-danger" role="alert">
       <p class="alert-heading fw-semibold mb-1"><%= pluralize(resource.errors.count, "error") %> prohibited this resource from being saved:</p>
@@ -21,7 +21,6 @@
   </div>
 
   <div class="col-12">
-    <%= form.submit (resource.persisted? ? "Update resource" : "Create resource"), class: "btn btn-primary" %>
+    <%= form.submit "Save", class: "btn btn-primary d-turbo-native-none", "data-bridge--form-target": "submit" %>
   </div>
 <% end %>
-

--- a/Demo/Server/package.json
+++ b/Demo/Server/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "^3.2.1",
+    "@hotwired/strada": "^1.0.0-beta1",
     "@hotwired/turbo-rails": "^7.3.0",
     "@popperjs/core": "^2.11.6",
     "bootstrap": "5.3.0-alpha1",

--- a/Demo/Server/yarn.lock
+++ b/Demo/Server/yarn.lock
@@ -117,6 +117,11 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.1.tgz#e3de23623b0c52c247aba4cd5d530d257008676b"
   integrity sha512-HGlzDcf9vv/EQrMJ5ZG6VWNs8Z/xMN+1o2OhV1gKiSG6CqZt5MCBB1gRg5ILiN3U0jEAxuDTNPRfBcnZBDmupQ==
 
+"@hotwired/strada@^1.0.0-beta1":
+  version "1.0.0-beta1"
+  resolved "https://registry.yarnpkg.com/@hotwired/strada/-/strada-1.0.0-beta1.tgz#95506e76d77cab389eb4315845673f5e8a758802"
+  integrity sha512-3J9Rc/qnWvnTnl9zD4l2ZHQQ3QbZANiKCh+AiYW2Lak+7JHx/U0AU+eoA4QDVlVylNFmKbxo3HTLCjEx9txqjA==
+
 "@hotwired/turbo-rails@^7.3.0":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.3.0.tgz#422c21752509f3edcd6c7b2725bbe9e157815f51"

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hotwired/turbo-ios", .upToNextMajor(from: "7.0.0")),
+        .package(url: "https://github.com/hotwired/strada-ios", branch: "main"),
     ],
     targets: [
         .target(
             name: "TurboNavigator",
             dependencies: [
                 .product(name: "Turbo", package: "turbo-ios"),
+                .product(name: "Strada", package: "strada-ios"),
             ],
             path: "Sources"
         ),
@@ -28,6 +30,6 @@ let package = Package(
             name: "TurboNavigatorTests",
             dependencies: ["TurboNavigator"],
             path: "Tests"
-        )
+        ),
     ]
 )

--- a/Sources/ProposalResult.swift
+++ b/Sources/ProposalResult.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Return from `handle(proposal:)` to route a custom controller.
 public enum ProposalResult: Equatable {
-    /// Route a `VisitableViewController`.
+    /// Route a `TurboWebViewController`.
     case accept
 
     /// Route a custom `UIViewController` or subclass

--- a/Sources/TurboConfig.swift
+++ b/Sources/TurboConfig.swift
@@ -1,3 +1,4 @@
+import Strada
 import WebKit
 
 public class TurboConfig {
@@ -5,14 +6,22 @@ public class TurboConfig {
 
     public static let shared = TurboConfig()
 
+    /// Set the class names of your Strada components to generate the correct user agent.
+    public var stradaComponentTypes = [BridgeComponent.Type]()
+
     /// Override to set a custom user agent.
     /// Include "Turbo Native" to use `turbo_native_app?` on your Rails server.
-    public var userAgent = "Turbo Native iOS"
+    public lazy var userAgent = {
+        let stradaSubstring = Strada.userAgentSubstring(for: stradaComponentTypes)
+        return "Turbo Native iOS \(stradaSubstring)"
+    }()
 
     /// Optionally customize the web views used by each Turbo Session.
     /// Ensure you return a new instance each time.
     public var makeCustomWebView: WebViewBlock = { (configuration: WKWebViewConfiguration) in
-        WKWebView(frame: .zero, configuration: configuration)
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        Bridge.initialize(webView)
+        return webView
     }
 
     // MARK: - Internal

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -11,9 +11,9 @@ public protocol TurboNavigationDelegate: AnyObject {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void)
 
     /// Optional. Accept or reject a visit proposal.
-    /// If accepted, you may provide a view controller to be displayed, otherwise a new `VisitableViewController` is displayed.
+    /// If accepted, you may provide a view controller to be displayed, otherwise a new `TurboWebViewController` is displayed.
     /// If rejected, no changes to navigation occur.
-    /// If not implemented, proposals are accepted and a new `VisitableViewController` is displayed.
+    /// If not implemented, proposals are accepted and a new `TurboWebViewController` is displayed.
     ///
     /// - Parameter proposal: navigation destination
     /// - Returns: how to react to the visit proposal

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -104,7 +104,7 @@ public class TurboNavigator {
     private func controller(for proposal: VisitProposal) -> UIViewController? {
         switch delegate.handle(proposal: proposal) {
         case .accept:
-            return VisitableViewController(url: proposal.url)
+            return TurboWebViewController(url: proposal.url)
         case .acceptCustom(let customViewController):
             return customViewController
         case .reject:
@@ -162,7 +162,7 @@ public class TurboNavigator {
         guard navigationController.viewControllers.count >= 2 else { return false }
 
         let previousController = navigationController.viewControllers[navigationController.viewControllers.count - 2]
-        if let previousVisitable = previousController as? VisitableViewController {
+        if let previousVisitable = previousController as? TurboWebViewController {
             return previousVisitable.visitableURL == url
         }
         return type(of: previousController) == type(of: controller)

--- a/Sources/TurboWebViewController.swift
+++ b/Sources/TurboWebViewController.swift
@@ -1,0 +1,48 @@
+import Strada
+import Turbo
+import WebKit
+
+public class TurboWebViewController: VisitableViewController, BridgeDestination {
+    private lazy var bridgeDelegate: BridgeDelegate = .init(
+        location: visitableURL.absoluteString,
+        destination: self,
+        componentTypes: TurboConfig.shared.stradaComponentTypes
+    )
+
+    // MARK: View lifecycle
+
+    override public func viewDidLoad() {
+        super.viewDidLoad()
+        bridgeDelegate.onViewDidLoad()
+    }
+
+    override public func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        bridgeDelegate.onViewWillAppear()
+    }
+
+    override public func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        bridgeDelegate.onViewDidAppear()
+    }
+
+    override public func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        bridgeDelegate.onViewWillDisappear()
+    }
+
+    override public func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        bridgeDelegate.onViewDidDisappear()
+    }
+
+    // MARK: Visitable
+
+    override public func visitableDidActivateWebView(_ webView: WKWebView) {
+        bridgeDelegate.webViewDidBecomeActive(webView)
+    }
+
+    override public func visitableDidDeactivateWebView() {
+        bridgeDelegate.webViewDidBecomeDeactivated()
+    }
+}

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -43,6 +43,6 @@ public extension VisitProposal {
             return viewController
         }
 
-        return VisitableViewController.pathConfigurationIdentifier
+        return TurboWebViewController.pathConfigurationIdentifier
     }
 }

--- a/Sources/VisitableViewControllerExtension.swift
+++ b/Sources/VisitableViewControllerExtension.swift
@@ -1,5 +1,5 @@
 import Turbo
 
-extension VisitableViewController: PathConfigurationIdentifiable {
+extension TurboWebViewController: PathConfigurationIdentifiable {
     public static var pathConfigurationIdentifier: String { "web" }
 }

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -23,12 +23,12 @@ final class TurboNavigatorTests: XCTestCase {
     func test_default_default_default_pushesOnMainStack() {
         navigator.route(VisitProposal(path: "/one"))
         XCTAssertEqual(navigationController.viewControllers.count, 2)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
 
         let proposal = VisitProposal(path: "/two")
         navigator.route(proposal)
         XCTAssertEqual(navigationController.viewControllers.count, 3)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -39,7 +39,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal(path: "/one")
         navigator.route(proposal)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -53,7 +53,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal(path: "/one")
         navigator.route(proposal)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -62,7 +62,7 @@ final class TurboNavigatorTests: XCTestCase {
         navigator.route(proposal)
 
         XCTAssertEqual(navigationController.viewControllers.count, 1)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -74,7 +74,7 @@ final class TurboNavigatorTests: XCTestCase {
         navigator.route(proposal)
 
         XCTAssertEqual(navigationController.viewControllers.count, 2)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -85,7 +85,7 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
         XCTAssertIdentical(navigationController.presentedViewController, modalNavigationController)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
 
@@ -96,7 +96,7 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertEqual(navigationController.viewControllers.count, 1)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
         XCTAssertIdentical(navigationController.presentedViewController, modalNavigationController)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
 
@@ -107,7 +107,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal()
         navigator.route(proposal)
         XCTAssertNil(navigationController.presentedViewController)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 2)
         assertVisited(url: proposal.url, on: .main)
     }
@@ -120,7 +120,7 @@ final class TurboNavigatorTests: XCTestCase {
         navigator.route(proposal)
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .main)
     }
 
@@ -131,7 +131,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal(path: "/two", context: .modal)
         navigator.route(proposal)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 2)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
 
@@ -142,7 +142,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal(path: "/two", action: .replace, context: .modal)
         navigator.route(proposal)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
 
@@ -153,7 +153,7 @@ final class TurboNavigatorTests: XCTestCase {
         let proposal = VisitProposal(path: "/two", context: .modal, presentation: .replace)
         navigator.route(proposal)
         XCTAssertEqual(modalNavigationController.viewControllers.count, 1)
-        XCTAssert(modalNavigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(modalNavigationController.viewControllers.last is TurboWebViewController)
         assertVisited(url: proposal.url, on: .modal)
     }
 
@@ -202,7 +202,7 @@ final class TurboNavigatorTests: XCTestCase {
         navigator.route(VisitProposal(presentation: .replaceRoot))
         XCTAssertNil(navigationController.presentedViewController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
-        XCTAssert(navigationController.viewControllers.last is VisitableViewController)
+        XCTAssert(navigationController.viewControllers.last is TurboWebViewController)
     }
 
     func test_presentingUIAlertController_doesNotWrapInNavigationController() {


### PR DESCRIPTION
This PR automatically configures and initializes Strada.

It provides the recommended `TurboWebViewController` from the [strada-ios docs](https://github.com/hotwired/strada-ios/blob/main/docs/QUICK-START.md#delegate-to-the-bridgedelegate-class), initializes the bridge on created web views, and provides a new configuration option to wire up Strada components.

```swift
TurboConfig.shared.stradaComponentTypes = [
    FormComponent.self,
    // ...
]
```

This drastically reduces the complexity of getting started with Strada. And provides a great jumping off point for when this library gets upstreamed into turbo-ios.

I've also included an example `FormComponent` in the demo app. But that is more to prove that it is all working – I don't think it needs to remain in the repo long term.

The downside is that Turbo Navigator (and eventually turbo-ios) depend directly on Strada. Personally, I think that that is OK but I am curious to hear others opinions on the matter.

What do you think, @jayohms and @olivaresf?

Edit: Additionally, we could get rid of `TurboWebViewController` entirely and roll this functionality directly into `VisitableViewController`. That would improve backwards compatibility a bit, too. And I don't think it would have any downside for folks _not_ using Strada (yet).