### PR TITLE
Option to implement `sessionDidFinishRequest(_:)`

### DIFF
--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -31,6 +31,9 @@ public protocol TurboNavigationDelegate: AnyObject {
     /// Optional. Implement to become the web view's navigation delegate after the initial cold boot visit is completed.
     /// https://github.com/hotwired/turbo-ios/blob/main/Docs/Overview.md#becoming-the-web-views-navigation-delegate
     func sessionDidLoadWebView(_ session: Session)
+
+    /// Optional. Useful for interacting with the web view after the page loads.
+    func sessionDidFinishRequest(_ session: Session)
 }
 
 public extension TurboNavigationDelegate {
@@ -56,6 +59,8 @@ public extension TurboNavigationDelegate {
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
     }
+
+    func sessionDidFinishRequest(_ session: Session) {}
 
     func sessionDidLoadWebView(_ session: Session) {}
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -266,6 +266,10 @@ extension TurboNavigator: SessionDelegate {
         delegate.didReceiveAuthenticationChallenge(challenge, completionHandler: completionHandler)
     }
 
+    public func sessionDidFinishRequest(_ session: Session) {
+        delegate.sessionDidFinishRequest(session)
+    }
+
     public func sessionDidLoadWebView(_ session: Session) {
         session.webView.navigationDelegate = session
         delegate.sessionDidLoadWebView(session)


### PR DESCRIPTION
This method has proved useful when copying over web-based cookies to native HTTP, enabling authenticated HTTP requests without building native authentication.

Yes, you use cookies to authenticate an API. Which isn't great but it is a nice shortcut for authenticated network requests.