### PR TITLE
Expose current navigation controller

### DIFF
--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         self.window?.makeKeyAndVisible()
 
-        self.window?.rootViewController = self.turboNavigator.rootViewController
+        self.window?.rootViewController = self.turboNavigator.currentNavigationController
         self.turboNavigator.route(baseURL)
     }
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -51,9 +51,9 @@ public class TurboNavigator {
         self.delegate = delegate
     }
 
-    public var rootViewController: UIViewController { navigationController }
-    public let navigationController: UINavigationController
-    public let modalNavigationController: UINavigationController
+    public var currentNavigationController: UINavigationController {
+        navigationController.presentedViewController != nil ? modalNavigationController : navigationController
+    }
 
     public func route(_ url: URL) {
         let options = VisitOptions(action: .advance, response: nil)
@@ -88,6 +88,9 @@ public class TurboNavigator {
     }
 
     // MARK: Internal
+
+    let navigationController: UINavigationController
+    let modalNavigationController: UINavigationController
 
     let session: Session
     let modalSession: Session

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -245,6 +245,22 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertNotEqual(navigator.session.activeVisitable?.visitableURL, proposal.url)
     }
 
+    func test_currentNavigationController_startsAsRoot() {
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.navigationController)
+    }
+
+    func test_currentNavigationController_modalPresented_isModal() {
+        navigator.route(VisitProposal(path: "/one"))
+        navigator.route(VisitProposal(path: "/two", context: .modal))
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.modalNavigationController)
+    }
+
+    func test_currentNavigationController_mainNavigation_isRoot() {
+        navigator.route(VisitProposal(path: "/one", context: .modal))
+        navigator.route(VisitProposal(path: "/two"))
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.navigationController)
+    }
+
     // MARK: Private
 
     private enum Context {


### PR DESCRIPTION
Helpful when completely custom navigation is required, like presenting a modal from `WKUIDelegate.webView(_:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:completionHandler:)`, for example:

```swift
import WebKit

extension SceneDelegate: WKUIDelegate {
    func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
        alert.addAction(UIAlertAction(title: "OK", style: .destructive) { _ in
            completionHandler()
        })
        self.turboNavigator.currentNavigationController.present(alert, animated: true)
    }
}
```

That last line is important - if we don't have access to the _currently_ visible navigation controller the app can crash. For example, if we try to present this alert on the main/root controller while a modal is displayed.

I like this approach because it gives the developer full control over when/how they want to present the dialog. But it also requires them to implement both this and the `confirm()` function.

Part of me thinks that both of these should be included directly in Turbo Navigator. But then if someone wants to do something entirely custom with `WKUIDelegate` I'm not sure how to expose that.