### PR TITLE
Handle JavaScript `alert()` and `confirm()` by default

### DIFF
--- a/Demo/Demo/SceneDelegate.swift
+++ b/Demo/Demo/SceneDelegate.swift
@@ -18,7 +18,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         self.window = UIWindow(windowScene: windowScene)
         self.window?.makeKeyAndVisible()
 
-        self.window?.rootViewController = self.turboNavigator.rootViewController
+        self.window?.rootViewController = self.turboNavigator.currentNavigationController
         self.turboNavigator.route(baseURL)
     }
 }

--- a/Demo/Server/app/javascript/controllers/alerts_controller.js
+++ b/Demo/Server/app/javascript/controllers/alerts_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  showAlert(event) {
+    event.preventDefault()
+    alert(event.currentTarget.dataset["title"])
+  }
+
+  showConfirm(event) {
+    event.preventDefault()
+    const result = confirm(event.currentTarget.dataset["title"])
+    alert(`You ${result ? "confirmed" : "cancelled"} the dialog.`)
+  }
+}

--- a/Demo/Server/app/javascript/controllers/index.js
+++ b/Demo/Server/app/javascript/controllers/index.js
@@ -3,3 +3,6 @@
 // ./bin/rails generate stimulus controllerName
 
 import { application } from "./application"
+
+import AlertsController from "./alerts_controller"
+application.register("alerts", AlertsController)

--- a/Demo/Server/app/views/layouts/application.html.erb
+++ b/Demo/Server/app/views/layouts/application.html.erb
@@ -12,7 +12,7 @@
     <%= hotwire_livereload_tags if Rails.env.development? %>
   </head>
 
-  <body class="<%= "turbo-native" if turbo_native_app? %>">
+  <body class="mb-5 <%= "turbo-native" if turbo_native_app? %>">
     <%= render "shared/navbar" %>
     <main class="container">
       <%= render "shared/flash" %>

--- a/Demo/Server/app/views/navigations/_item.html.erb
+++ b/Demo/Server/app/views/navigations/_item.html.erb
@@ -5,7 +5,7 @@
 
   <div class="w-100 mx-auto">
     <p class="fs-5 mb-0"><%= name %></p>
-    <p class="mb-0 text-muted"><%= description %></p>
+    <p class="mb-0 text-muted"><%= local_assigns[:description] || yield %></p>
   </div>
 
   <div class="col flex-grow-0 flex-shrink-1 my-auto">

--- a/Demo/Server/app/views/navigations/show.html.erb
+++ b/Demo/Server/app/views/navigations/show.html.erb
@@ -3,7 +3,7 @@
 <p class="my-3">This screen was pushed onto the navigation stack.</p>
 <p>This is the default behavior, no custom options are required.</p>
 
-<div class="list-group list-group-flush mx-n3 sm:mx-0">
+<div class="list-group list-group-flush mx-n3 sm:mx-0" data-controller="alerts">
   <%= render "navigations/item",
     path: second_navigation_path,
     icon: "bi-arrow-right",
@@ -34,4 +34,20 @@
     icon: "bi-bug",
     name: "Error handling",
     description: "Visit a page that does not exist (404)." %>
+
+  <%= render "navigations/item",
+    path: "#",
+    icon: "bi-exclamation-circle",
+    name: "JavaScript alert dialog",
+    data: {action: "alerts#showAlert", title: "A JavaScript alert."} do %>
+    Present a JavaScript <code>alert()</code>.
+  <% end %>
+
+  <%= render "navigations/item",
+    path: "#",
+    icon: "bi-question-circle",
+    name: "JavaScript confirm dialog",
+    data: {action: "alerts#showConfirm", title: "Are you sure?"} do %>
+    Present a JavaScript <code>confirm()</code>, like via <code>data-turbo-confirm</code>.
+  <% end %>
 </div>

--- a/Demo/Server/app/views/resources/show.html.erb
+++ b/Demo/Server/app/views/resources/show.html.erb
@@ -5,5 +5,5 @@
 
 <div class="btn-group d-flex d-sm-inline-flex mt-4" role="group">
   <%= link_to "Edit resource", edit_resource_path(@resource), class: "btn btn-outline-secondary" %>
-  <%= link_to "Delete resource", resource_path(@resource), data: {turbo_method: :delete}, class: "btn btn-outline-danger" %>
+  <%= link_to "Delete resource", resource_path(@resource), data: {turbo_method: :delete, turbo_confirm: "Delete this resource?"}, class: "btn btn-outline-danger" %>
 </div>

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -34,6 +34,12 @@ public protocol TurboNavigationDelegate: AnyObject {
 
     /// Optional. Useful for interacting with the web view after the page loads.
     func sessionDidFinishRequest(_ session: Session)
+
+    /// Optional. Override to customize the behavior when a JavaScript `alert()` dialog is shown.
+    func controller(_ controller: UIViewController, runJavaScriptAlertPanelWithMessage message: String, completionHandler: @escaping () -> Void)
+
+    /// Optional. Override to customize the behavior when a JavaScript `confirm()` dialog is shown.
+    func controller(_ controller: UIViewController, runJavaScriptConfirmPanelWithMessage message: String, completionHandler: @escaping (Bool) -> Void)
 }
 
 public extension TurboNavigationDelegate {
@@ -63,4 +69,23 @@ public extension TurboNavigationDelegate {
     func sessionDidFinishRequest(_ session: Session) {}
 
     func sessionDidLoadWebView(_ session: Session) {}
+
+    func controller(_ controller: UIViewController, runJavaScriptAlertPanelWithMessage message: String, completionHandler: @escaping () -> Void) {
+        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Close", style: .default) { _ in
+            completionHandler()
+        })
+        controller.present(alert, animated: true)
+    }
+
+    func controller(_ controller: UIViewController, runJavaScriptConfirmPanelWithMessage message: String, completionHandler: @escaping (Bool) -> Void) {
+        let alert = UIAlertController(title: message, message: nil, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .destructive) { _ in
+            completionHandler(true)
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel) { _ in
+            completionHandler(false)
+        })
+        controller.present(alert, animated: true)
+    }
 }

--- a/Sources/TurboNavigator.swift
+++ b/Sources/TurboNavigator.swift
@@ -51,9 +51,9 @@ public class TurboNavigator {
         self.delegate = delegate
     }
 
-    public var rootViewController: UIViewController { navigationController }
-    public let navigationController: UINavigationController
-    public let modalNavigationController: UINavigationController
+    public var currentNavigationController: UINavigationController {
+        navigationController.presentedViewController != nil ? modalNavigationController : navigationController
+    }
 
     public func route(_ url: URL) {
         let options = VisitOptions(action: .advance, response: nil)
@@ -88,6 +88,9 @@ public class TurboNavigator {
     }
 
     // MARK: Internal
+
+    let navigationController: UINavigationController
+    let modalNavigationController: UINavigationController
 
     let session: Session
     let modalSession: Session

--- a/Tests/TurboNavigatorTests.swift
+++ b/Tests/TurboNavigatorTests.swift
@@ -245,6 +245,22 @@ final class TurboNavigatorTests: XCTestCase {
         XCTAssertNotEqual(navigator.session.activeVisitable?.visitableURL, proposal.url)
     }
 
+    func test_currentNavigationController_startsAsRoot() {
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.navigationController)
+    }
+
+    func test_currentNavigationController_modalPresented_isModal() {
+        navigator.route(VisitProposal(path: "/one"))
+        navigator.route(VisitProposal(path: "/two", context: .modal))
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.modalNavigationController)
+    }
+
+    func test_currentNavigationController_mainNavigation_isRoot() {
+        navigator.route(VisitProposal(path: "/one", context: .modal))
+        navigator.route(VisitProposal(path: "/two"))
+        XCTAssertIdentical(navigator.currentNavigationController, navigator.navigationController)
+    }
+
     // MARK: Private
 
     private enum Context {


### PR DESCRIPTION
This PR builds on the idea from #61, baking in default behavior for JavaScript `alert()` and `confirm()` dialogs.

I'm in favor of having this live in Turbo Navigator / turbo-ios. Especially because a developer can implement the delegate callbacks to customize the behavior entirely.

But it requires the `TurboNavigator` class to become the UI delegate of the web view. Which means we close off all the other methods in `WKUIDelegate`. I don't want to expose every single one of these with a default (empty) implementation. But I'm not sure of a more elegant way to handle it.

<img width="946" alt="Artboard" src="https://github.com/joemasilotti/TurboNavigator/assets/2092156/1924aa81-0993-456c-9df5-4f3271a68f6e">