### PR TITLE
Verify if the external URL contains 'tel:' and 'mailto:' links.

### DIFF
--- a/Demo/Server/app/views/navigations/show.html.erb
+++ b/Demo/Server/app/views/navigations/show.html.erb
@@ -30,6 +30,12 @@
     description: "Do nothing." %>
 
   <%= render "navigations/item",
+    path: "sms:555-555-5555",
+    icon: "bi-chat",
+    name: "<code>sms:</code> URLs".html_safe,
+    description: "Handle non-http(s) URLs natively." %>
+
+  <%= render "navigations/item",
     path: "/not_found",
     icon: "bi-bug",
     name: "Error handling",

--- a/README.md
+++ b/README.md
@@ -309,9 +309,13 @@ TurboConfig.shared.makeCustomWebView = { (configuration: WKWebViewConfiguration)
 
 ### Customize behavior for external URLs
 
-Turbo cannot navigate across domains because page visits are done via JavaScript. A clicked link that points to a different domain is considered external.
+Turbo cannot navigate across domains because page visits are done via JavaScript. A tapped link that points to a different domain is considered external.
 
-By default, a `SFSafariViewController` is presented. This can be overridden by implementing the following delegate method.
+By default, web URLs (`http://` and `https://`) are presented via the in-app browser, `SFSafariViewController`. Everything else is opened natively. For example, `tel:` and `sms:` links are opened, when possible, in Phone.app or Messages.app.
+
+If you want to register _additional_ URL schemes you need to follow the [steps outlined here](https://developer.apple.com/documentation/uikit/uiapplication/1622952-canopenurl#discussion) to add an entry in your Info.plist.
+
+This behavior can be overridden by implementing the following delegate method.
 
 ```swift
 class MyCustomClass: TurboNavigationDelegate {

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -48,20 +48,16 @@ public extension TurboNavigationDelegate {
     }
 
     func openExternalURL(_ url: URL, from controller: UIViewController) {
-        if url.scheme == "mailto" || url.scheme == "tel" {
-            if UIApplication.shared.canOpenURL(url) {
-                return UIApplication.shared.open(url, options: [:], completionHandler: nil)
-            } else {
-                return print("Can't open email client.")
+        if ["http", "https"].contains(url.scheme) {
+            let safariViewController = SFSafariViewController(url: url)
+            safariViewController.modalPresentationStyle = .pageSheet
+            if #available(iOS 15.0, *) {
+                safariViewController.preferredControlTintColor = .tintColor
             }
+            controller.present(safariViewController, animated: true)
+        } else if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
         }
-      
-        let safariViewController = SFSafariViewController(url: url)
-        safariViewController.modalPresentationStyle = .pageSheet
-        if #available(iOS 15.0, *) {
-            safariViewController.preferredControlTintColor = .tintColor
-        }
-        controller.present(safariViewController, animated: true)
     }
 
     func didReceiveAuthenticationChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {

--- a/Sources/TurboNavigationDelegate.swift
+++ b/Sources/TurboNavigationDelegate.swift
@@ -48,6 +48,14 @@ public extension TurboNavigationDelegate {
     }
 
     func openExternalURL(_ url: URL, from controller: UIViewController) {
+        if url.scheme == "mailto" || url.scheme == "tel" {
+            if UIApplication.shared.canOpenURL(url) {
+                return UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                return print("Can't open email client.")
+            }
+        }
+      
         let safariViewController = SFSafariViewController(url: url)
         safariViewController.modalPresentationStyle = .pageSheet
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
The app was crashing when external links included 'mailto:' or 'tel:'. This pull request adds a feature to validate external URLs for the presence of 'tel:' and 'mailto:' links, aiming to enhance both usability and accessibility on the platform.

I'm not a Swift programmer, so , add your thoughts about is correct or not, please.