### PR TITLE
Support other casings for `view-controller`

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ It shows off most of the navigation flows outlined above. There is also an examp
 
 You can also implement an optional method on the `TurboNavigationDelegate` to handle custom routing.
 
-This is useful to break out of the default behavior and/or render a native screen. You may inspect the provided proposal and decide routing based on any of its properties. For custom native screens, you may also include a `"view-controller"` property that will be passed along.
+This is useful to break out of the default behavior and/or render a native screen. You may inspect the provided proposal and decide routing based on any of its properties. For custom native screens, you may also include a `"view-controller"` (or `"view_controller"` or `"viewController"`) property that will be passed along.
 
 ```json
 {

--- a/Sources/VisitProposalExtension.swift
+++ b/Sources/VisitProposalExtension.swift
@@ -39,10 +39,8 @@ public extension VisitProposal {
     ///
     /// A default value is provided in case the view controller property is missing from the configuration file. This will route the default `VisitableViewController`.
     var viewController: String {
-        if let viewController = properties["view-controller"] as? String {
-            return viewController
-        }
+        let viewControllers = ["view-controller", "view_controller", "viewController"].map { properties[$0] }.filter { $0 as? String }
 
-        return VisitableViewController.pathConfigurationIdentifier
+        return viewControllers.first || VisitableViewController.pathConfigurationIdentifier
     }
 }


### PR DESCRIPTION
The decision to use dash-casing for the `view-controller` property matches the multi-word precedent set by the [Turbo iOS examples][]. However, the [Turbo Android examples][] uses snake_casing.

It's unlikely that an Android app and an iOS app will share exact copies of a path configuration file's structure and data. However, it's possible that they'd share a similar server-side backend to generate those files, or a shared naming convention across those files.

The `view-controller` appears to be the only multi-word key expected and supported out-of-the-box, with the expectation that other keys can be used to inform bespoke features in app-specific contexts.

This commit expands that support to match other naming conventions, mainly snake_case and camelCase.

[Turbo iOS examples]: https://github.com/hotwired/turbo-ios/blob/c9d060fcdec136c3808cd0764e956d375012c6fb/Docs/PathConfiguration.md#path-configuration
[Turbo Android examples]: https://github.com/hotwired/turbo-android/blob/bf945e18aed3d5749c9efc6e228d98bc012878af/docs/PATH-CONFIGURATION.md#path-configuration